### PR TITLE
Add bank seller plugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bankseller/BankSellerConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bankseller/BankSellerConfig.java
@@ -1,0 +1,9 @@
+package net.runelite.client.plugins.microbot.bankseller;
+
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+
+@ConfigGroup("bankseller")
+public interface BankSellerConfig extends Config {
+}
+

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bankseller/BankSellerOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bankseller/BankSellerOverlay.java
@@ -1,0 +1,37 @@
+package net.runelite.client.plugins.microbot.bankseller;
+
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.ui.overlay.OverlayPanel;
+import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.components.LineComponent;
+import net.runelite.client.ui.overlay.components.TitleComponent;
+
+import javax.inject.Inject;
+import java.awt.*;
+
+public class BankSellerOverlay extends OverlayPanel {
+
+    @Inject
+    BankSellerOverlay(BankSellerPlugin plugin) {
+        super(plugin);
+        setPosition(OverlayPosition.TOP_LEFT);
+        setNaughty();
+    }
+
+    @Override
+    public Dimension render(Graphics2D graphics) {
+        panelComponent.setPreferredSize(new Dimension(200, 300));
+        panelComponent.getChildren().add(TitleComponent.builder()
+                .text("Bank Seller")
+                .color(Color.GREEN)
+                .build());
+
+        panelComponent.getChildren().add(LineComponent.builder().build());
+
+        panelComponent.getChildren().add(LineComponent.builder()
+                .left(Microbot.status)
+                .build());
+        return super.render(graphics);
+    }
+}
+

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bankseller/BankSellerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bankseller/BankSellerPlugin.java
@@ -2,9 +2,7 @@ package net.runelite.client.plugins.microbot.bankseller;
 
 import com.google.inject.Provides;
 import lombok.extern.slf4j.Slf4j;
-import net.runelite.api.events.GameTick;
 import net.runelite.client.config.ConfigManager;
-import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.OverlayManager;
@@ -52,15 +50,5 @@ public class BankSellerPlugin extends Plugin {
         overlayManager.remove(overlay);
     }
 
-    int ticks = 10;
-
-    @Subscribe
-    public void onGameTick(GameTick tick) {
-        if (ticks > 0) {
-            ticks--;
-        } else {
-            ticks = 10;
-        }
-    }
 }
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bankseller/BankSellerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bankseller/BankSellerPlugin.java
@@ -1,0 +1,66 @@
+package net.runelite.client.plugins.microbot.bankseller;
+
+import com.google.inject.Provides;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.events.GameTick;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.eventbus.Subscribe;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.ui.overlay.OverlayManager;
+
+import javax.inject.Inject;
+import java.awt.*;
+
+@PluginDescriptor(
+        name = PluginDescriptor.Default + "Bank Seller",
+        description = "Withdraws tradeable items from the bank and sells them at the Grand Exchange",
+        tags = {"bank", "sell", "ge"},
+        enabledByDefault = false
+)
+@Slf4j
+public class BankSellerPlugin extends Plugin {
+
+    @Inject
+    private BankSellerConfig config;
+
+    @Provides
+    BankSellerConfig provideConfig(ConfigManager configManager) {
+        return configManager.getConfig(BankSellerConfig.class);
+    }
+
+    @Inject
+    private OverlayManager overlayManager;
+
+    @Inject
+    private BankSellerOverlay overlay;
+
+    @Inject
+    private BankSellerScript script;
+
+    @Override
+    protected void startUp() throws AWTException {
+        if (overlayManager != null) {
+            overlayManager.add(overlay);
+        }
+        script.run(config);
+    }
+
+    @Override
+    protected void shutDown() {
+        script.shutdown();
+        overlayManager.remove(overlay);
+    }
+
+    int ticks = 10;
+
+    @Subscribe
+    public void onGameTick(GameTick tick) {
+        if (ticks > 0) {
+            ticks--;
+        } else {
+            ticks = 10;
+        }
+    }
+}
+

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bankseller/BankSellerScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bankseller/BankSellerScript.java
@@ -1,0 +1,126 @@
+package net.runelite.client.plugins.microbot.bankseller;
+
+import net.runelite.api.gameval.ItemID;
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.plugins.microbot.Script;
+import net.runelite.client.plugins.microbot.util.bank.Rs2Bank;
+import net.runelite.client.plugins.microbot.util.grandexchange.Rs2GrandExchange;
+import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
+import net.runelite.client.plugins.microbot.util.inventory.Rs2ItemModel;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static net.runelite.client.plugins.microbot.util.Global.sleep;
+import static net.runelite.client.plugins.microbot.util.Global.sleepUntil;
+
+public class BankSellerScript extends Script {
+
+    public boolean run(BankSellerConfig config) {
+        Microbot.enableAutoRunOn = false;
+        mainScheduledFuture = scheduledExecutorService.scheduleWithFixedDelay(() -> {
+            try {
+                if (!Microbot.isLoggedIn() || !super.run() || !isRunning()) {
+                    return;
+                }
+
+                // If inventory empty attempt to withdraw tradeable items from bank
+                if (Rs2Inventory.isEmpty()) {
+                    if (!withdrawTradeablesFromBank()) {
+                        Microbot.log("No more tradeable items. Stopping Bank Seller.");
+                        shutdown();
+                    }
+                    return;
+                }
+
+                // Ensure grand exchange is open
+                if (!Rs2GrandExchange.isOpen()) {
+                    Rs2GrandExchange.openExchange();
+                    sleepUntil(Rs2GrandExchange::isOpen, 5000);
+                    return;
+                }
+
+                sellInventory();
+
+                if (Rs2Inventory.isEmpty() && !bankHasTradeables()) {
+                    Microbot.log("Finished selling all tradeable items.");
+                    shutdown();
+                }
+            } catch (Exception ex) {
+                System.out.println(ex.getMessage());
+            }
+        }, 0, 2000, TimeUnit.MILLISECONDS);
+        return true;
+    }
+
+    private boolean bankHasTradeables() {
+        return Rs2Bank.getAll(item -> item.isTradeable() && item.getId() != ItemID.COINS)
+                .findAny()
+                .isPresent();
+    }
+
+    private boolean withdrawTradeablesFromBank() {
+        if (!Rs2Bank.openBank()) {
+            return true; // try again later
+        }
+        Rs2Bank.depositAll();
+        sleepUntil(Rs2Inventory::isEmpty, 3000);
+
+        // Ensure items are withdrawn as notes so they stack in the inventory
+        Rs2Bank.setWithdrawAsNote();
+
+        List<Rs2ItemModel> tradeables = Rs2Bank.getAll(item -> item.isTradeable() && item.getId() != ItemID.COINS)
+                .collect(Collectors.toList());
+        if (tradeables.isEmpty()) {
+            Rs2Bank.closeBank();
+            sleepUntil(() -> !Rs2Bank.isOpen(), 2000);
+            return false; // nothing to withdraw
+        }
+
+        for (Rs2ItemModel item : tradeables) {
+            if (Rs2Inventory.isFull()) {
+                break;
+            }
+            int id = item.getId();
+            int before = Rs2Inventory.get(id) != null ? Rs2Inventory.get(id).getQuantity() : 0;
+            if (Rs2Bank.withdrawAll(id)) {
+                sleepUntil(() -> Rs2Inventory.get(id) != null && Rs2Inventory.get(id).getQuantity() > before, 2400);
+                sleep(200, 400);
+            }
+        }
+        Rs2Bank.closeBank();
+        sleepUntil(() -> !Rs2Bank.isOpen(), 2000);
+        return true;
+    }
+
+    private void sellInventory() {
+        List<Rs2ItemModel> items = Rs2Inventory.items()
+                .filter(item -> item.isTradeable() && item.getId() != ItemID.COINS)
+                .collect(Collectors.toList());
+
+        for (Rs2ItemModel item : items) {
+            while (Rs2GrandExchange.getAvailableSlot() == null) {
+                if (Rs2GrandExchange.hasSoldOffer()) {
+                    Rs2GrandExchange.collectAllToBank();
+                    sleep(600, 1200);
+                } else {
+                    return; // wait for slot on next iteration
+                }
+            }
+            int price = Rs2GrandExchange.getSellPrice(item.getId());
+            if (price <= 0) {
+                price = Rs2GrandExchange.getPrice(item.getId());
+            }
+            Rs2GrandExchange.sellItem(item.getName(), item.getQuantity(), price);
+            sleepUntil(() -> !Rs2GrandExchange.isOfferScreenOpen(), 5000);
+            sleep(600, 1200);
+        }
+    }
+
+    @Override
+    public void shutdown() {
+        super.shutdown();
+    }
+}
+


### PR DESCRIPTION
## Summary
- add Bank Seller plugin that withdraws tradeables and sells them on the Grand Exchange
- ensure tradeable items are withdrawn as notes for efficient selling
- include overlay and config scaffolding

## Testing
- `mvn -q -pl runelite-client -am package -DskipTests` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689f4bc3784883309ffd8bb3052bd344