### PR TITLE
Add Bank Organizer microbot plugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bankorganizer/BankOrganizerConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bankorganizer/BankOrganizerConfig.java
@@ -1,0 +1,138 @@
+package net.runelite.client.plugins.microbot.bankorganizer;
+
+import net.runelite.client.config.*;
+
+@ConfigGroup("bankorganizer")
+public interface BankOrganizerConfig extends Config {
+    // Presets section
+    @ConfigSection(
+            name = "Presets",
+            description = "Built-in category sets",
+            position = 0
+    )
+    String sectionPresets = "sectionPresets";
+
+    @ConfigItem(keyName = "useDefaultPreset", name = "Use Default Preset", description = "Create standard tabs incl. Raids/Slayer/Barrows", position = 1, section = sectionPresets)
+    default boolean useDefaultPreset() { return true; }
+
+    // Combination Tags section
+    @ConfigSection(
+            name = "Combination Tags",
+            description = "Derived tags across categories",
+            position = 10
+    )
+    String sectionCombos = "sectionCombos";
+
+    @ConfigItem(keyName = "enableCombos", name = "Enable built-in combos", description = "Enable all preset combo toggles below", position = 11, section = sectionCombos)
+    default boolean enableCombos() { return true; }
+
+    // Built-in combos
+    @ConfigItem(keyName = "comboRaidsAll", name = "Combo: Raids Gear (All)", description = "Union of raids gear/armour/weapons/consumables", position = 12, section = sectionCombos)
+    default boolean comboRaidsAll() { return true; }
+    @ConfigItem(keyName = "comboRaidsTOA", name = "Combo: Raids — TOA", description = "TOA-leaning items (fang/ward/lightbearer/masori)", position = 13, section = sectionCombos)
+    default boolean comboRaidsTOA() { return true; }
+    @ConfigItem(keyName = "comboRaidsCOX", name = "Combo: Raids — COX", description = "COX-leaning items (tbow/DHCB/ancestral)", position = 14, section = sectionCombos)
+    default boolean comboRaidsCOX() { return true; }
+    @ConfigItem(keyName = "comboRaidsTOB", name = "Combo: Raids — TOB", description = "TOB-leaning items (scythe/avernic/sang)", position = 15, section = sectionCombos)
+    default boolean comboRaidsTOB() { return false; }
+
+    @ConfigItem(keyName = "comboSlayer", name = "Combo: Slayer Tasks", description = "Slayer essentials (mask/helm, cannon, ammo, food, pots, tp)", position = 16, section = sectionCombos)
+    default boolean comboSlayer() { return true; }
+    @ConfigItem(keyName = "comboPvP", name = "Combo: PvP / PK", description = "Common PK loadouts (combat, armour, ammo, tp, food, pots)", position = 17, section = sectionCombos)
+    default boolean comboPvP() { return false; }
+    @ConfigItem(keyName = "comboSkilling", name = "Combo: Skilling Sets", description = "Tools + common mats for multi-skill sessions", position = 18, section = sectionCombos)
+    default boolean comboSkilling() { return false; }
+    @ConfigItem(keyName = "comboClue", name = "Combo: Clue Prep", description = "Clue items (teleports, runes, spade, stash)", position = 19, section = sectionCombos)
+    default boolean comboClue() { return false; }
+
+    // Custom keyword combos
+    @ConfigItem(keyName = "customCombo1Name", name = "Custom combo 1 — name", description = "Name for custom combo tag", position = 20, section = sectionCombos)
+    default String customCombo1Name() { return ""; }
+    @ConfigItem(keyName = "customCombo1Keywords", name = "Custom combo 1 — keywords", description = "Comma terms to include (name contains)", position = 21, section = sectionCombos)
+    default String customCombo1Keywords() { return ""; }
+    @ConfigItem(keyName = "customCombo2Name", name = "Custom combo 2 — name", description = "Name for custom combo tag", position = 22, section = sectionCombos)
+    default String customCombo2Name() { return ""; }
+    @ConfigItem(keyName = "customCombo2Keywords", name = "Custom combo 2 — keywords", description = "Comma terms to include (name contains)", position = 23, section = sectionCombos)
+    default String customCombo2Keywords() { return ""; }
+
+    // Preset Packs
+    enum PresetPack { NONE, RAIDS, SLAYER, IRONMAN, SKILLING, BARROWS, CLUES, ALL }
+
+    @ConfigSection(
+            name = "Preset Packs",
+            description = "Apply curated rule sets",
+            position = 24
+    )
+    String sectionPacks = "sectionPacks";
+
+    @ConfigItem(keyName = "selectedPack", name = "Select pack", description = "Choose a preset pack to apply or load", position = 25, section = sectionPacks)
+    default PresetPack selectedPack() { return PresetPack.RAIDS; }
+
+    // Rule‑Editor JSON
+    @ConfigSection(
+            name = "Rule‑Editor (JSON)",
+            description = "Define unlimited combos",
+            position = 30
+    )
+    String sectionRuleEditor = "sectionRuleEditor";
+
+    @ConfigItem(keyName = "ruleEditorJson", name = "Rules JSON", description = "Array of combo definitions. You can edit.", position = 31, section = sectionRuleEditor)
+    default String ruleEditorJson() { return PresetPacks.DEFAULT_RULES_JSON; }
+
+    // Base settings
+    @ConfigItem(keyName = "prefixTabs", name = "Prefix tabs with order number", description = "Adds 01_, 02_, ... so tags sort predictably", position = 40)
+    default boolean prefixTabs() { return true; }
+    @ConfigItem(keyName = "decorate", name = "Decorate tab names", description = "Adds small symbols like ⚔️, ⛏️, 🧪, 🍖", position = 41)
+    default boolean decorate() { return true; }
+    @ConfigItem(keyName = "autoArrange", name = "Auto arrange (drag)", description = "Physically reorders bank by simulated drags (Microbot). Turn OFF if you only want tags.", position = 42)
+    default boolean autoArrange() { return false; }
+    @ConfigItem(keyName = "arrangeBy", name = "Arrange order", description = "Order within a category", position = 43)
+    default ArrangeOrder arrangeOrder() { return ArrangeOrder.ALPHA; }
+    @ConfigItem(keyName = "includePlaceholders", name = "Include placeholders", description = "Also tag placeholders in the bank", position = 44)
+    default boolean includePlaceholders() { return true; }
+    @ConfigItem(keyName = "dryRun", name = "Dry run", description = "Log actions without modifying anything", position = 45)
+    default boolean dryRun() { return false; }
+    @ConfigItem(keyName = "layoutFilePath", name = "Export/Import file path", description = "Path for JSON layout file", position = 46)
+    default String layoutFilePath() { return "bank_layout.json"; }
+
+    // Category keyword extenders
+    @ConfigItem(keyName = "extraKeywordsRaids", name = "Extra keywords — Raids", description = "Comma-separated extra terms to classify as Raids", position = 50)
+    default String extraKeywordsRaids() { return ""; }
+    @ConfigItem(keyName = "extraKeywordsSlayer", name = "Extra keywords — Slayer", description = "Comma-separated extra terms to classify as Slayer", position = 51)
+    default String extraKeywordsSlayer() { return ""; }
+    @ConfigItem(keyName = "extraKeywordsBarrows", name = "Extra keywords — Barrows", description = "Comma-separated extra terms to classify as Barrows", position = 52)
+    default String extraKeywordsBarrows() { return ""; }
+
+    enum ArrangeOrder { ALPHA, GE_PRICE_DESC, HA_VALUE_DESC, WEAPON_ARMOUR_FIRST }
+
+    // Physical arrange scope
+    enum ArrangeScope { WHOLE_BANK, CURRENT_VIEW_ONLY, NATIVE_TABS }
+
+    // Humanization / safety
+    @ConfigItem(keyName = "dragMinMs", name = "Min drag delay (ms)", description = "Minimum delay between drags", position = 60)
+    default int dragMinMs() { return 80; }
+    @ConfigItem(keyName = "dragMaxMs", name = "Max drag delay (ms)", description = "Maximum delay between drags", position = 61)
+    default int dragMaxMs() { return 160; }
+    @ConfigItem(keyName = "arrangeScope", name = "Arrange scope", description = "Where to physically reorder", position = 62)
+    default ArrangeScope arrangeScope() { return ArrangeScope.CURRENT_VIEW_ONLY; }
+
+    // Multi‑tab Arrange section
+    @ConfigSection(
+            name = "Multi‑tab Arrange",
+            description = "Physically reorder multiple native tabs in one run",
+            position = 63
+    )
+    String sectionMultiTab = "sectionMultiTab";
+
+    @ConfigItem(keyName = "tabsToArrange", name = "Tabs to arrange", description = "Comma/Range list, e.g. 1-4,6,8 (native tabs). 0 = main.", position = 64, section = sectionMultiTab)
+    default String tabsToArrange() { return "1-8"; }
+
+    @ConfigItem(keyName = "includeMainTab", name = "Include main tab (0)", description = "Whether to include the main (All) tab when multi‑arranging", position = 65, section = sectionMultiTab)
+    default boolean includeMainTab() { return false; }
+
+    @ConfigItem(keyName = "tabSwitchMinMs", name = "Min tab switch delay (ms)", description = "Delay between switching tabs (min)", position = 66, section = sectionMultiTab)
+    default int tabSwitchMinMs() { return 120; }
+
+    @ConfigItem(keyName = "tabSwitchMaxMs", name = "Max tab switch delay (ms)", description = "Delay between switching tabs (max)", position = 67, section = sectionMultiTab)
+    default int tabSwitchMaxMs() { return 240; }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bankorganizer/BankOrganizerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bankorganizer/BankOrganizerPlugin.java
@@ -1,0 +1,42 @@
+package net.runelite.client.plugins.microbot.bankorganizer;
+
+import com.google.inject.Provides;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Client;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.ui.ClientToolbar;
+import net.runelite.client.ui.NavigationButton;
+
+import javax.inject.Inject;
+
+@Slf4j
+@PluginDescriptor(
+        name = "Bank Organizer (Microbot)",
+        description = "Organize your bank via tags + combos + rule editor + preset packs",
+        tags = {"bank", "organize", "tags", "combos", "microbot"}
+)
+public class BankOrganizerPlugin extends Plugin {
+    @Inject private Client client;
+    @Inject private ClientToolbar clientToolbar;
+    @Inject private ConfigManager configManager;
+    @Inject private OrganizerService service;
+    @Inject private BankOrganizerConfig config;
+
+    private NavigationButton navBtn;
+
+    @Provides BankOrganizerConfig provideConfig(ConfigManager cm) { return cm.getConfig(BankOrganizerConfig.class); }
+
+    @Override protected void startUp() {
+        service.init(client, config, configManager);
+        navBtn = OrganizerPanel.createNavButton(service);
+        clientToolbar.addNavigation(navBtn);
+        log.info("Bank Organizer started");
+    }
+    @Override protected void shutDown() {
+        if (navBtn != null) clientToolbar.removeNavigation(navBtn);
+        service.reset();
+        log.info("Bank Organizer stopped");
+    }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bankorganizer/Category.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bankorganizer/Category.java
@@ -1,0 +1,26 @@
+package net.runelite.client.plugins.microbot.bankorganizer;
+
+enum Category {
+    RAIDS(1, "Raids", "🏛️"),
+    SLAYER(2, "Slayer", "😈"),
+    BARROWS(3, "Barrows", "⚰️"),
+    COMBAT(4, "Combat", "⚔️"),
+    ARMOUR(5, "Armour", "🛡️"),
+    AMMO(6, "Ammo", "🎯"),
+    POTIONS(7, "Potions", "🧪"),
+    FOOD(8, "Food", "🍖"),
+    RUNES(9, "Runes", "🔮"),
+    TELEPORTS(10, "Teleports", "🧭"),
+    SKILLING(11, "Skilling", "⛏️"),
+    FARMING(12, "Farming", "🌱"),
+    CLUE(13, "Clues", "🧩"),
+    TOOLS(14, "Tools", "🧰"),
+    QUEST(15, "Quest", "📜"),
+    MISC(16, "Misc", "📦");
+
+    private final int order; private final String display; private final String emoji;
+    Category(int order, String display, String emoji) { this.order=order; this.display=display; this.emoji=emoji; }
+    public int order() { return order; }
+    public String displayName() { return display; }
+    public String emoji() { return emoji; }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bankorganizer/CategoryRules.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bankorganizer/CategoryRules.java
@@ -1,0 +1,62 @@
+package net.runelite.client.plugins.microbot.bankorganizer;
+
+import net.runelite.api.ItemComposition;
+import net.runelite.client.util.Text;
+import java.util.*;
+
+final class CategoryRules {
+    private CategoryRules() {}
+
+    static final List<Category> DEFAULT_ORDER = Arrays.asList(
+            Category.RAIDS, Category.SLAYER, Category.BARROWS,
+            Category.COMBAT, Category.ARMOUR, Category.AMMO,
+            Category.POTIONS, Category.FOOD, Category.RUNES, Category.TELEPORTS,
+            Category.SKILLING, Category.FARMING, Category.CLUE, Category.TOOLS,
+            Category.QUEST, Category.MISC
+    );
+
+    static Category classify(ItemComposition ic) {
+        String n = Text.standardize(ic.getName());
+        if (isBarrows(n)) return Category.BARROWS;
+        if (isSlayer(n)) return Category.SLAYER;
+        if (isRaids(n)) return Category.RAIDS;
+
+        if (nameAny(n, "potion","brew","restore","super","overload","antidote","antipoison","stamina","prayer potion","energy potion"))
+            return Category.POTIONS;
+        if (nameAny(n, "shark","anglerfish","karambwan","lobster","trout","salmon","cake","pizza","wine","meat","stew"))
+            return Category.FOOD;
+        if (nameAny(n, "rune","runes","astral","law rune","nature rune","blood rune","soul rune"))
+            return Category.RUNES;
+        if (nameAny(n, "teleport","tablet","tabs","chronicle","xeric","games necklace","dueling ring","necklace of passage","skills necklace","combat bracelet"))
+            return Category.TELEPORTS;
+        if (nameAny(n, "arrow","bolt","javelin","throwing","dart","ammo","cannonball"))
+            return Category.AMMO;
+        if (nameAny(n, "helm","coif","hat","mask","body","plate","legs","skirt","gloves","boots","shield","cape","defender","ring","amulet"))
+            return Category.ARMOUR;
+        if (nameAny(n, "sword","2h","scimitar","mace","spear","halberd","maul","bow","staff","knife","whip","godsword","claws"))
+            return Category.COMBAT;
+        if (nameAny(n, "spade","hammer","chisel","axe","pickaxe","harpoon","net","tinderbox","small fishing","butterfly net","impling jar","pestle","mortar"))
+            return Category.TOOLS;
+        if (nameAny(n, "seed","sapling","compost","watering can","rake","seed dibber","secateurs","plant cure","ultracompost"))
+            return Category.FARMING;
+        if (nameAny(n, "clue","casket","totem","torn clue","clue scroll"))
+            return Category.CLUE;
+        if (nameAny(n, "quest","sigil","key","orb","notes","device","journal","talisman","enchantment scroll","god book"))
+            return Category.QUEST;
+        if (isSkilling(ic)) return Category.SKILLING;
+        return Category.MISC;
+    }
+
+    static boolean nameAny(String name, String... needles) { for (String s : needles) if (name.contains(s)) return true; return false; }
+
+    private static boolean isSkilling(ItemComposition ic) {
+        String n = ic.getName().toLowerCase();
+        return n.contains("ore") || n.contains("bar") || n.contains("log") || n.contains("herb") || n.contains("raw ") || n.contains("leather") || n.contains("gem") || n.contains("plank");
+    }
+
+    private static boolean isRaids(String n) {
+        return nameAny(n, "twisted bow","kodai","ancestral","dragon hunter crossbow","elder maul","dexterous prayer scroll","arcane prayer scroll","olmlet","twisted","olm","xeric's","xerics","masori","fang","lightbearer","ward of elidinis","sanguinesti","scythe","verzik");
+    }
+    private static boolean isSlayer(String n) { return nameAny(n, "slayer","black mask","slayer helm","slayer helmet","brimstone key","konar","cannon","cannon base","cannon stand","cannon barrels","cannon furnace","slayer ring","broad bolt","broad arrows"); }
+    private static boolean isBarrows(String n) { return nameAny(n, "ahrim","dharok","guthan","karil","torag","verac","barrows","amulet of the damned"); }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bankorganizer/ComboRules.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bankorganizer/ComboRules.java
@@ -81,8 +81,15 @@ final class ComboRules {
 
     private static Set<Integer> allIds(ItemManager itemManager) {
         Set<Integer> set = new LinkedHashSet<>();
-        int limit = Math.max(30000, itemManager.getItemCount());
-        for (int id = 0; id < limit; id++) { try { itemManager.getItemComposition(id); set.add(id); } catch (Exception ignored) { } }
+        final int limit = 30_000; // approximate max item ID; RuneLite API lacks a count method
+        for (int id = 0; id < limit; id++) {
+            try {
+                itemManager.getItemComposition(id);
+                set.add(id);
+            }
+            catch (Exception ignored) {
+            }
+        }
         return set;
     }
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bankorganizer/ComboRules.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bankorganizer/ComboRules.java
@@ -1,0 +1,103 @@
+package net.runelite.client.plugins.microbot.bankorganizer;
+
+import net.runelite.client.game.ItemManager;
+import java.util.*;
+
+final class ComboRules {
+    private ComboRules() {}
+
+    static Map<String, Set<Integer>> buildBuiltInCombos(Map<Category, List<OrganizerService.ItemStack>> base,
+                                                        ItemManager itemManager,
+                                                        BankOrganizerConfig cfg) {
+        Map<String, Set<Integer>> out = new LinkedHashMap<>();
+        if (!cfg.enableCombos()) return out;
+
+        if (cfg.comboRaidsAll()) out.put(tag("Raids Gear (All)", "🏛️"), union(base,
+                Category.RAIDS, Category.COMBAT, Category.ARMOUR, Category.RUNES, Category.TELEPORTS, Category.FOOD, Category.POTIONS));
+        if (cfg.comboRaidsTOA()) out.put(tag("Raids — TOA", "🏜️"), filterByName(union(base,
+                Category.RAIDS, Category.COMBAT, Category.ARMOUR, Category.RUNES, Category.TELEPORTS, Category.FOOD, Category.POTIONS), itemManager,
+                "fang","masori","elidinis","ward","lightbearer","akh"));
+        if (cfg.comboRaidsCOX()) out.put(tag("Raids — COX", "⛰️"), filterByName(union(base,
+                Category.RAIDS, Category.COMBAT, Category.ARMOUR, Category.RUNES, Category.TELEPORTS, Category.FOOD, Category.POTIONS), itemManager,
+                "twisted","tbow","ancestral","kodai","dinh","olm"));
+        if (cfg.comboRaidsTOB()) out.put(tag("Raids — TOB", "🕍"), filterByName(union(base,
+                Category.RAIDS, Category.COMBAT, Category.ARMOUR, Category.RUNES, Category.TELEPORTS, Category.FOOD, Category.POTIONS), itemManager,
+                "sanguinesti","scythe","aver","verzik","justiciar"));
+
+        if (cfg.comboSlayer()) out.put(tag("Slayer Tasks", "😈"), union(base,
+                Category.SLAYER, Category.COMBAT, Category.ARMOUR, Category.AMMO, Category.FOOD, Category.POTIONS, Category.TELEPORTS, Category.TOOLS));
+        if (cfg.comboPvP()) out.put(tag("PvP / PK", "🗡️"), union(base,
+                Category.COMBAT, Category.ARMOUR, Category.AMMO, Category.TELEPORTS, Category.FOOD, Category.POTIONS));
+        if (cfg.comboSkilling()) out.put(tag("Skilling Sets", "🧰"), union(base,
+                Category.SKILLING, Category.TOOLS, Category.FARMING, Category.TELEPORTS, Category.FOOD, Category.POTIONS));
+        if (cfg.comboClue()) out.put(tag("Clue Prep", "🧩"), union(base,
+                Category.CLUE, Category.TELEPORTS, Category.RUNES, Category.TOOLS, Category.FOOD));
+
+        addCustomKeyword(out, itemManager, cfg.customCombo1Name(), cfg.customCombo1Keywords());
+        addCustomKeyword(out, itemManager, cfg.customCombo2Name(), cfg.customCombo2Keywords());
+        return out;
+    }
+
+    static Map<String, Set<Integer>> buildRuleEditorCombos(Map<Category, List<OrganizerService.ItemStack>> base,
+                                                           ItemManager itemManager,
+                                                           String json) {
+        Map<String, Set<Integer>> out = new LinkedHashMap<>();
+        if (json == null || json.trim().isEmpty()) return out;
+        java.util.List<java.util.Map<String, Object>> rules = TinyJson.parseArrayOfObjects(json.trim());
+        for (java.util.Map<String,Object> rule : rules) {
+            String name = TinyJson.asString(rule.get("name"));
+            if (name == null || name.isEmpty()) continue;
+            java.util.List<String> catNames = TinyJson.asStringList(rule.get("includeCategories"));
+            java.util.List<String> kw = TinyJson.asStringList(rule.get("includeKeywords"));
+            Set<Integer> ids = new LinkedHashSet<>();
+            if (catNames != null && !catNames.isEmpty()) {
+                java.util.List<Category> cats = new java.util.ArrayList<>();
+                for (String cn : catNames) { try { cats.add(Category.valueOf(cn.trim().toUpperCase())); } catch (Exception ignored) {} }
+                ids.addAll(union(base, cats.toArray(new Category[0])));
+            }
+            if (kw != null && !kw.isEmpty()) ids = filterByName(ids, itemManager, kw.toArray(new String[0]));
+            out.put("🧩 " + name, ids);
+        }
+        return out;
+    }
+
+    static Set<Integer> union(Map<Category, List<OrganizerService.ItemStack>> base, Category... cats) {
+        Set<Integer> out = new LinkedHashSet<>();
+        for (Category c : cats) {
+            java.util.List<OrganizerService.ItemStack> list = base.get(c);
+            if (list == null) continue;
+            for (OrganizerService.ItemStack s : list) out.add(s.id);
+        }
+        return out;
+    }
+
+    private static String tag(String base, String emoji) { return emoji + " " + base; }
+
+    private static void addCustomKeyword(Map<String, Set<Integer>> out, ItemManager itemManager, String name, String csv) {
+        if (name == null || name.trim().isEmpty()) return;
+        Set<Integer> set = filterByName(allIds(itemManager), itemManager, csv);
+        out.put("🧩 " + name.trim(), set);
+    }
+
+    private static Set<Integer> allIds(ItemManager itemManager) {
+        Set<Integer> set = new LinkedHashSet<>();
+        int limit = Math.max(30000, itemManager.getItemCount());
+        for (int id = 0; id < limit; id++) { try { itemManager.getItemComposition(id); set.add(id); } catch (Exception ignored) { } }
+        return set;
+    }
+
+    static Set<Integer> filterByName(Set<Integer> ids, ItemManager itemManager, String... needles) {
+        if (needles == null || needles.length == 0) return ids;
+        Set<Integer> out = new LinkedHashSet<>();
+        java.util.List<String> nlist = new java.util.ArrayList<>();
+        if (needles.length == 1 && needles[0] != null && needles[0].contains(",")) {
+            for (String part : needles[0].split(",")) if (!part.trim().isEmpty()) nlist.add(part.trim().toLowerCase());
+        } else {
+            for (String s : needles) if (s != null && !s.trim().isEmpty()) nlist.add(s.trim().toLowerCase());
+        }
+        for (int id : ids) {
+            try { String n = itemManager.getItemComposition(id).getName().toLowerCase(); for (String k : nlist) { if (n.contains(k)) { out.add(id); break; } } } catch (Exception ignored) {}
+        }
+        return out;
+    }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bankorganizer/MicrobotBankMover.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bankorganizer/MicrobotBankMover.java
@@ -1,0 +1,111 @@
+package net.runelite.client.plugins.microbot.bankorganizer;
+
+import net.runelite.api.*;
+import java.util.*;
+
+final class MicrobotBankMover {
+    private MicrobotBankMover() {}
+
+    static void reorderBank(Client client, java.util.List<OrganizerService.ItemStack> desired, java.util.function.Consumer<String> log, int minDelayMs, int maxDelayMs) {
+        final Widget bankContainer = client.getWidget(WidgetInfo.BANK_ITEM_CONTAINER);
+        if (bankContainer == null || bankContainer.getDynamicChildren() == null) { log.accept("Bank widget not found"); return; }
+        ItemContainer bank = client.getItemContainer(InventoryID.BANK);
+        if (bank == null) { log.accept("Bank not open"); return; }
+        Item[] items = bank.getItems();
+        Random rng = new Random();
+        int n = Math.min(items.length, desired.size());
+        for (int targetSlot = 0; targetSlot < n; targetSlot++) {
+            int wantId = desired.get(targetSlot).id;
+            if (slotHas(items, targetSlot, wantId)) continue;
+            int fromSlot = findSlot(items, wantId, targetSlot+1);
+            if (fromSlot == -1) continue;
+            ensureSlotVisible(client, bankContainer, fromSlot);
+            ensureSlotVisible(client, bankContainer, targetSlot);
+            dragItem(client, bankContainer, fromSlot, targetSlot);
+            log.accept("Moved id="+wantId+" from "+fromSlot+" -> "+targetSlot);
+            Item tmp = items[targetSlot]; items[targetSlot] = items[fromSlot]; items[fromSlot] = tmp;
+            sleep(rng, minDelayMs, maxDelayMs);
+        }
+    }
+
+    static java.util.Set<Integer> visibleBankSlots(Client client) {
+        java.util.Set<Integer> set = new java.util.LinkedHashSet<>();
+        ItemContainer bank = client.getItemContainer(InventoryID.BANK);
+        if (bank == null || bank.getItems() == null) return set;
+        for (int i = 0; i < bank.getItems().length; i++) set.add(i);
+        return set;
+    }
+
+    static int activeNativeTab(Client client) {
+        try { return client.getVarbitValue(net.runelite.api.Varbits.CURRENT_BANK_TAB); } catch (Throwable t) { return -1; }
+    }
+
+    static java.util.Set<Integer> slotsInNativeTab(Client client, int tabId) {
+        // Best-effort: when a native tab is selected, the bank view shows only that tab's items
+        return visibleBankSlots(client);
+    }
+
+    static boolean selectNativeTab(Client client, int tabIndex) {
+        try {
+            // Tab 0 = main (All). Others are numbered left->right as 1..n
+            Widget tabs = client.getWidget(WidgetInfo.BANK_TAB_CONTAINER);
+            if (tabs == null) return false;
+            Widget[] ch = tabs.getDynamicChildren();
+            if (ch == null || ch.length == 0) return tabIndex == 0; // assume main selected
+
+            int clickChild = -1;
+            if (tabIndex == 0) {
+                clickChild = -2; // parent fallback for main tab
+            } else {
+                int count = 0;
+                for (Widget w : ch) {
+                    if (w == null) continue;
+                    if (w.getWidth() > 0 && w.getHeight() > 0) {
+                        count++;
+                        if (count == tabIndex) { clickChild = w.getIndex(); break; }
+                    }
+                }
+            }
+            if (clickChild == -1) return false;
+
+            if (clickChild == -2) {
+                client.invokeMenuAction("", "", 1, MenuAction.WIDGET_TYPE_1.getId(), tabs.getIndex(), tabs.getId());
+            } else {
+                client.invokeMenuAction("", "", 1, MenuAction.WIDGET_TYPE_1.getId(), clickChild, tabs.getId());
+            }
+
+            long start = System.currentTimeMillis();
+            int expected = tabIndex;
+            while (System.currentTimeMillis() - start < 500) {
+                int cur = activeNativeTab(client);
+                if (cur == expected || (tabIndex == 0 && (cur <= 0))) break;
+                try { Thread.sleep(20); } catch (InterruptedException ignored) {}
+            }
+            return true;
+        } catch (Throwable t) { return false; }
+    }
+
+    static void sleep(Random rng, int minMs, int maxMs) { try { int span = Math.max(0, maxMs - minMs); int d = Math.max(0, minMs + (span > 0 ? rng.nextInt(span + 1) : 0)); Thread.sleep(d); } catch (InterruptedException ignored) {} }
+
+    // Auto-scroll to reveal a slot before dragging (best-effort; safe no-op if not needed)
+    private static void ensureSlotVisible(Client client, Widget container, int slot) {
+        if (container == null) return;
+        try {
+            final int itemsPerRow = 8; // bank grid
+            final int row = Math.max(0, slot / itemsPerRow);
+            final int rowHeight = 36; // approx
+            final int targetY = row * rowHeight;
+            int cur = container.getScrollY();
+            int h = container.getScrollHeight();
+            int vis = container.getHeight();
+            if (targetY < cur || targetY > cur + vis - rowHeight) {
+                int newY = Math.min(Math.max(0, targetY - rowHeight), Math.max(0, h - vis));
+                container.setScrollY(newY);
+            }
+        } catch (Throwable ignored) { }
+    }
+
+    private static boolean slotHas(Item[] items, int slot, int id) { return slot < items.length && items[slot] != null && items[slot].getId() == id; }
+    private static int findSlot(Item[] items, int id, int start) { for (int i=start; i<items.length; i++) if (items[i]!=null && items[i].getId()==id) return i; return -1; }
+    private static void dragItem(Client client, Widget container, int from, int to) { int parentId = container.getId(); client.invokeMenuAction("", "", 1, MenuAction.WIDGET_TYPE_1.getId(), from, parentId); client.invokeMenuAction("", "", 1, MenuAction.WIDGET_TYPE_2.getId(), to, parentId); }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bankorganizer/OrganizerPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bankorganizer/OrganizerPanel.java
@@ -1,0 +1,82 @@
+package net.runelite.client.plugins.microbot.bankorganizer;
+
+import net.runelite.client.ui.ColorScheme;
+import net.runelite.client.ui.NavigationButton;
+import net.runelite.client.ui.PluginPanel;
+
+import javax.swing.*;
+import java.awt.*;
+
+public class OrganizerPanel extends PluginPanel {
+    private final OrganizerService service;
+
+    private OrganizerPanel(OrganizerService service) {
+        this.service = service;
+        setLayout(new BorderLayout());
+        setBackground(ColorScheme.DARK_GRAY_COLOR);
+
+        JPanel top = new JPanel(new GridLayout(0,1,6,6));
+        JButton scan = new JButton("Scan & Tag bank");
+        JButton makeTabs = new JButton("Create/Update tabs");
+        JButton arrange = new JButton("Arrange (virtual tags)");
+        JButton arrangePhysical = new JButton("Arrange (physical)");
+        JButton arrangePhysicalAll = new JButton("Arrange (physical) — All Tabs");
+        JButton clear = new JButton("Clear preset tags");
+        JButton combos = new JButton("Apply Built‑in Combos");
+        JButton ruleCombos = new JButton("Apply Rule‑Editor Combos");
+        JButton snapshot = new JButton("Snapshot → Dated JSON");
+        JButton exportClip = new JButton("Export → Clipboard");
+        JButton importClip = new JButton("Import ← Clipboard");
+        JButton exportFile = new JButton("Export → File");
+        JButton importFile = new JButton("Import ← File");
+        JButton resetPresets = new JButton("Restore Default Presets");
+
+        // Preset Pack controls
+        JPanel packRow = new JPanel(new FlowLayout(FlowLayout.LEFT, 6, 0));
+        JComboBox<BankOrganizerConfig.PresetPack> packBox = new JComboBox<>(BankOrganizerConfig.PresetPack.values());
+        JButton packLoad = new JButton("Load Pack → Rules JSON");
+        JButton packApply = new JButton("Apply Pack (no edit)");
+        packRow.add(new JLabel("Preset Pack:"));
+        packRow.add(packBox);
+        packRow.add(packLoad);
+        packRow.add(packApply);
+
+        scan.addActionListener(e -> service.scanAndTag());
+        makeTabs.addActionListener(e -> service.createOrUpdateTabs());
+        arrange.addActionListener(e -> service.arrangeVirtual());
+        arrangePhysical.addActionListener(e -> service.arrangePhysical());
+        arrangePhysicalAll.addActionListener(e -> service.arrangePhysicalAllTabs());
+        clear.addActionListener(e -> service.clearPresetTags());
+        combos.addActionListener(e -> service.applyCombinationTags());
+        ruleCombos.addActionListener(e -> service.applyRuleEditorCombos());
+        snapshot.addActionListener(e -> service.snapshotToDatedFile());
+        exportClip.addActionListener(e -> service.exportLayoutToClipboard());
+        importClip.addActionListener(e -> service.importLayoutFromUser());
+        exportFile.addActionListener(e -> service.exportLayoutToFile());
+        importFile.addActionListener(e -> service.importLayoutFromFile());
+        packLoad.addActionListener(e -> service.loadPresetPackToRulesJson((BankOrganizerConfig.PresetPack) packBox.getSelectedItem()));
+        packApply.addActionListener(e -> service.applyPresetPack((BankOrganizerConfig.PresetPack) packBox.getSelectedItem()));
+        resetPresets.addActionListener(e -> service.restoreDefaultRuleJson());
+
+        top.add(scan); top.add(makeTabs); top.add(arrange); top.add(arrangePhysical); top.add(arrangePhysicalAll); top.add(clear);
+        top.add(combos); top.add(ruleCombos); top.add(snapshot);
+        top.add(packRow);
+        top.add(resetPresets);
+        top.add(exportClip); top.add(importClip); top.add(exportFile); top.add(importFile);
+
+        add(top, BorderLayout.NORTH);
+        JTextArea log = service.getLogArea();
+        log.setEditable(false);
+        add(new JScrollPane(log), BorderLayout.CENTER);
+    }
+
+    public static NavigationButton createNavButton(OrganizerService service) {
+        OrganizerPanel panel = new OrganizerPanel(service);
+        return NavigationButton.builder()
+                .tooltip("Bank Organizer")
+                .icon(OrganizerService.ICON)
+                .priority(7)
+                .panel(panel)
+                .build();
+    }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bankorganizer/OrganizerService.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bankorganizer/OrganizerService.java
@@ -1,0 +1,339 @@
+package net.runelite.client.plugins.microbot.bankorganizer;
+
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.*;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.game.ItemManager;
+import net.runelite.client.util.Text;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import javax.swing.*;
+import java.awt.image.BufferedImage;
+import java.io.*;
+import java.text.SimpleDateFormat;
+import java.util.*;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Singleton
+public class OrganizerService {
+    @Inject private ItemManager itemManager;
+
+    private Client client;
+    private BankOrganizerConfig config;
+    private ConfigManager configManager;
+
+    @Getter private final JTextArea logArea = new JTextArea();
+    static final javax.swing.Icon ICON = new javax.swing.ImageIcon(new BufferedImage(16,16,BufferedImage.TYPE_INT_ARGB));
+
+    private static final String BANK_TAGS_GROUP = "banktags";
+
+    public void init(Client client, BankOrganizerConfig config, ConfigManager cfg) { this.client = client; this.config = config; this.configManager = cfg; logArea.setText(""); }
+    public void reset() { logArea.setText(""); }
+
+    // ==== Public actions ====
+    public void scanAndTag() {
+        if (!bankOpen()) { logln("Open your bank first."); return; }
+        logln("Scanning bank items…");
+        Map<Category, List<ItemStack>> base = categorizeCurrentBank();
+        if (config.dryRun()) { base.forEach((c, list) -> logln(c.displayName()+": "+list.size()+" items")); return; }
+        writeBankTags(base);
+        logln("Tagging complete.");
+    }
+
+    public void createOrUpdateTabs() {
+        if (config.dryRun()) { logln("[dry-run] Would ensure tab names via tags."); return; }
+        ensureTagSeeds();
+        logln("Tabs ensured. Use Bank Tags/Bank Tag Tabs to show them.");
+    }
+
+    public void arrangeVirtual() {
+        if (!config.autoArrange()) { logln("Auto arrange is disabled in config."); return; }
+        if (!bankOpen()) { logln("Open your bank first."); return; }
+        Map<Category, List<ItemStack>> map = categorizeCurrentBank();
+        List<ItemStack> order = desiredOrder(map);
+        if (config.dryRun()) { logln("[dry-run] Would reorder (virtual) " + order.size() + " slots."); return; }
+        MicrobotBankMover.reorderBank(client, order, this::logln, config.dragMinMs(), config.dragMaxMs());
+    }
+
+    public void arrangePhysical() {
+        if (!bankOpen()) { logln("Open your bank first."); return; }
+        Map<Category, List<ItemStack>> map = categorizeCurrentBank();
+        List<ItemStack> fullOrder = desiredOrder(map);
+        List<ItemStack> target;
+        switch (config.arrangeScope()) {
+            case WHOLE_BANK:
+                target = fullOrder; break;
+            case NATIVE_TABS:
+                target = filterToNativeTab(fullOrder); break;
+            case CURRENT_VIEW_ONLY:
+            default:
+                target = filterToCurrentView(fullOrder); break;
+        }
+        if (target.isEmpty()) { logln("Nothing to arrange for the selected scope."); return; }
+        if (config.dryRun()) { logln("[dry-run] Would physically reorder " + target.size() + " slots ("+config.arrangeScope()+")."); return; }
+        MicrobotBankMover.reorderBank(client, target, this::logln, config.dragMinMs(), config.dragMaxMs());
+    }
+
+    public void arrangePhysicalAllTabs() {
+        if (!bankOpen()) { logln("Open your bank first."); return; }
+        java.util.List<Integer> tabs = parseTabList(config.tabsToArrange(), config.includeMainTab());
+        if (tabs.isEmpty()) { logln("No tabs selected to arrange."); return; }
+        java.util.Random rng = new java.util.Random();
+        int processed = 0;
+        for (int tab : tabs) {
+            if (!MicrobotBankMover.selectNativeTab(client, tab)) { logln("Could not select tab " + tab + ". Skipping."); continue; }
+            try { Thread.sleep(config.tabSwitchMinMs() + rng.nextInt(Math.max(1, config.tabSwitchMaxMs() - config.tabSwitchMinMs() + 1))); } catch (InterruptedException ignored) {}
+            Map<Category, List<ItemStack>> map = categorizeCurrentBank();
+            List<ItemStack> order = desiredOrder(map);
+            List<ItemStack> target = filterToNativeTab(order);
+            if (target.isEmpty()) { logln("Tab " + tab + ": no items to arrange."); continue; }
+            processed++;
+            if (config.dryRun()) { logln("[dry-run] Tab " + tab + ": would reorder " + target.size() + " slots."); continue; }
+            MicrobotBankMover.reorderBank(client, target, s -> logln("[Tab " + tab + "] " + s), config.dragMinMs(), config.dragMaxMs());
+        }
+        logln("Multi-tab arrange complete. Tabs processed: " + processed + ".");
+    }
+
+    public void clearPresetTags() {
+        if (config.dryRun()) { logln("[dry-run] Would clear preset tags"); return; }
+        for (Category c : CategoryRules.DEFAULT_ORDER) {
+            configManager.unsetConfiguration(BANK_TAGS_GROUP, tagName(c));
+        }
+        logln("Cleared preset tags.");
+    }
+
+    // ==== Internals ====
+    private boolean bankOpen() { return client != null && client.getItemContainer(InventoryID.BANK) != null; }
+
+    private Map<String,String> readAllPresetTags() {
+        Map<String,String> out = new LinkedHashMap<>();
+        for (Category c : CategoryRules.DEFAULT_ORDER) {
+            String key = tagName(c);
+            String val = configManager.getConfiguration(BANK_TAGS_GROUP, key);
+            if (val != null) out.put(key, val);
+        }
+        return out;
+    }
+
+    private void writeTagsMap(Map<String,String> map) {
+        for (Map.Entry<String,String> e : map.entrySet())
+            configManager.setConfiguration(BANK_TAGS_GROUP, e.getKey(), e.getValue());
+    }
+
+    private List<ItemStack> desiredOrder(Map<Category, List<ItemStack>> map) {
+        List<ItemStack> order = new ArrayList<>();
+        for (Category c : CategoryRules.DEFAULT_ORDER) order.addAll(sortWithin(map.getOrDefault(c, Collections.emptyList())));
+        return order;
+    }
+
+    private List<ItemStack> filterToCurrentView(List<ItemStack> order) {
+        Set<Integer> visibleSlots = MicrobotBankMover.visibleBankSlots(client);
+        List<ItemStack> out = new ArrayList<>();
+        for (ItemStack s : order) if (visibleSlots.contains(s.slot)) out.add(s);
+        return out;
+    }
+
+    private List<ItemStack> filterToNativeTab(List<ItemStack> order) {
+        int activeTab = MicrobotBankMover.activeNativeTab(client);
+        if (activeTab <= 0) return filterToCurrentView(order);
+        Set<Integer> tabSlots = MicrobotBankMover.slotsInNativeTab(client, activeTab);
+        List<ItemStack> out = new ArrayList<>();
+        for (ItemStack s : order) if (tabSlots.contains(s.slot)) out.add(s);
+        return out;
+    }
+
+    private List<ItemStack> sortWithin(List<ItemStack> items) {
+        BankOrganizerConfig.ArrangeOrder mode = config.arrangeOrder();
+        switch (mode) {
+            case GE_PRICE_DESC:
+                return items.stream().sorted((a,b)->Integer.compare(gePrice(b.id), gePrice(a.id))).collect(Collectors.toList());
+            case HA_VALUE_DESC:
+                return items.stream().sorted((a,b)->Integer.compare(haValue(b.id), haValue(a.id))).collect(Collectors.toList());
+            case WEAPON_ARMOUR_FIRST:
+                return items.stream().sorted((a,b)->{
+                    int aw = scoreWeaponArmour(b.id) - scoreWeaponArmour(a.id);
+                    if (aw != 0) return aw;
+                    return Text.standardize(itemName(a.id)).compareTo(Text.standardize(itemName(b.id)));
+                }).collect(Collectors.toList());
+            case ALPHA:
+            default:
+                return items.stream().sorted(java.util.Comparator.comparing(s->Text.standardize(itemName(s.id)))).collect(Collectors.toList());
+        }
+    }
+
+    private int scoreWeaponArmour(int id) {
+        String n = itemManager.getItemComposition(id).getName().toLowerCase();
+        if (n.contains("sword")||n.contains("bow")||n.contains("staff")||n.contains("2h")||n.contains("dagger")||n.contains("mace")||n.contains("scimitar")) return 3;
+        if (n.contains("helm")||n.contains("body")||n.contains("plate")||n.contains("legs")||n.contains("shield")||n.contains("boots")||n.contains("gloves")||n.contains("cape")) return 2;
+        return 0;
+    }
+
+    private String itemName(int id) { return itemManager.getItemComposition(id).getName(); }
+    private int gePrice(int id) { try { return itemManager.getItemPrice(id); } catch (Exception e) { return 0; } }
+    private int haValue(int id) { return itemManager.getItemComposition(id).getHaPrice(); }
+
+    private void writeBankTags(Map<Category, List<ItemStack>> map) {
+        for (Map.Entry<Category, List<ItemStack>> e : map.entrySet())
+            saveTag(tagName(e.getKey()), toIdSet(e.getValue()));
+    }
+    private Set<Integer> toIdSet(List<ItemStack> items) { Set<Integer> ids = new LinkedHashSet<>(); for (ItemStack s: items) ids.add(s.id); return ids; }
+
+    private String tagName(Category c) {
+        String base = c.displayName();
+        if (config.decorate()) base = c.emoji() + " " + base;
+        if (config.prefixTabs()) base = String.format("%02d_", c.order()) + base;
+        return base;
+    }
+
+    void saveTag(String tag, Set<Integer> ids) {
+        String csv = ids.stream().map(String::valueOf).collect(Collectors.joining(","));
+        configManager.setConfiguration(BANK_TAGS_GROUP, tag, csv);
+        logln("Tag "+tag+" <= "+ids.size()+" ids");
+    }
+
+    private void ensureTagSeeds() {
+        for (Category c : CategoryRules.DEFAULT_ORDER)
+            if (configManager.getConfiguration(BANK_TAGS_GROUP, tagName(c)) == null)
+                configManager.setConfiguration(BANK_TAGS_GROUP, tagName(c), "");
+    }
+
+    private Map<Category, List<ItemStack>> categorizeCurrentBank() {
+        ItemContainer bank = client.getItemContainer(InventoryID.BANK);
+        Map<Category, List<ItemStack>> map = new EnumMap<>(Category.class);
+        if (bank==null) return map;
+        Item[] items = bank.getItems();
+        if (items==null) return map;
+        for (int slot=0; slot<items.length; slot++) {
+            Item it = items[slot];
+            if (it==null||it.getId()<=0) continue;
+            if (it.getId()==ItemID.BANK_FILLER && !config.includePlaceholders()) continue;
+            ItemComposition comp = itemManager.getItemComposition(it.getId());
+            Category c = classifyWithExtras(comp);
+            map.computeIfAbsent(c, __->new ArrayList<>()).add(new ItemStack(it.getId(), slot, it.getQuantity()));
+        }
+        return map;
+    }
+
+    private Category classifyWithExtras(ItemComposition ic) {
+        String n = ic.getName().toLowerCase();
+        if (extraHit(n, config.extraKeywordsRaids())) return Category.RAIDS;
+        if (extraHit(n, config.extraKeywordsSlayer())) return Category.SLAYER;
+        if (extraHit(n, config.extraKeywordsBarrows())) return Category.BARROWS;
+        return CategoryRules.classify(ic);
+    }
+    private boolean extraHit(String name, String csv) {
+        if (csv==null||csv.trim().isEmpty()) return false;
+        for (String t: csv.split(",")) { String s=t.trim().toLowerCase(); if(!s.isEmpty() && name.contains(s)) return true; }
+        return false;
+    }
+
+    // Built-in combos & Rule-editor combos
+    public void applyCombinationTags() {
+        if (!bankOpen()) { logln("Open your bank first."); return; }
+        Map<Category, List<ItemStack>> base = categorizeCurrentBank();
+        Map<String, Set<Integer>> combos = ComboRules.buildBuiltInCombos(base, itemManager, config);
+        if (config.dryRun()) { logln("[dry-run] Would write " + combos.size() + " combo tags"); return; }
+        for (Map.Entry<String, Set<Integer>> e : combos.entrySet()) saveTag(e.getKey(), e.getValue());
+        logln("Wrote " + combos.size() + " built‑in combo tags.");
+    }
+
+    public void applyRuleEditorCombos() {
+        if (!bankOpen()) { logln("Open your bank first."); return; }
+        Map<Category, List<ItemStack>> base = categorizeCurrentBank();
+        Map<String, Set<Integer>> combos = ComboRules.buildRuleEditorCombos(base, itemManager, config.ruleEditorJson());
+        if (combos.isEmpty()) { logln("No rule‑editor combos found (check your JSON)."); return; }
+        if (config.dryRun()) { logln("[dry-run] Would write " + combos.size() + " rule‑editor combo tags"); return; }
+        for (Map.Entry<String, Set<Integer>> e : combos.entrySet()) saveTag(e.getKey(), e.getValue());
+        logln("Wrote " + combos.size() + " rule‑editor combo tags.");
+    }
+
+    // Preset Packs
+    public void loadPresetPackToRulesJson(BankOrganizerConfig.PresetPack pack) {
+        String json = PresetPacks.forPack(pack);
+        configManager.setConfiguration("bankorganizer", "ruleEditorJson", json);
+        logln("Loaded pack '"+pack+"' into Rules JSON (edit in config if you like).");
+    }
+
+    public void applyPresetPack(BankOrganizerConfig.PresetPack pack) {
+        if (!bankOpen()) { logln("Open your bank first."); return; }
+        String json = PresetPacks.forPack(pack);
+        Map<Category, List<ItemStack>> base = categorizeCurrentBank();
+        Map<String, Set<Integer>> combos = ComboRules.buildRuleEditorCombos(base, itemManager, json);
+        if (combos.isEmpty()) { logln("Pack has no rules."); return; }
+        if (config.dryRun()) { logln("[dry-run] Would write " + combos.size() + " pack tags"); return; }
+        for (Map.Entry<String, Set<Integer>> e : combos.entrySet()) saveTag(e.getKey(), e.getValue());
+        logln("Applied pack '"+pack+"' → " + combos.size() + " tags written.");
+    }
+
+    public void restoreDefaultRuleJson() {
+        configManager.setConfiguration("bankorganizer", "ruleEditorJson", PresetPacks.DEFAULT_RULES_JSON);
+        logln("Restored default Rules JSON presets.");
+    }
+
+    // Import/Export/Snapshot
+    public void exportLayoutToClipboard() { try { copyToClipboard(toJson(readAllPresetTags())); logln("Exported layout to clipboard."); } catch (Exception ex) { logln("Export failed: "+ex.getMessage()); } }
+    public void importLayoutFromUser() { try { String input = JOptionPane.showInputDialog(null, "Paste layout JSON:"); if (input==null||input.trim().isEmpty()) { logln("Import cancelled."); return; } writeTagsMap(fromJson(input.trim())); logln("Imported layout."); } catch (Exception ex) { logln("Import failed: "+ex.getMessage()); } }
+    public void exportLayoutToFile() { try { String json = toJson(readAllPresetTags()); writeString(new File(config.layoutFilePath()), json); logln("Exported layout to file: "+new File(config.layoutFilePath()).getAbsolutePath()); } catch (Exception ex) { logln("Export failed: "+ex.getMessage()); } }
+    public void importLayoutFromFile() { try { File f=new File(config.layoutFilePath()); if(!f.exists()){ logln("Import file not found: "+f.getAbsolutePath()); return;} writeTagsMap(fromJson(readString(f))); logln("Imported layout from file."); } catch (Exception ex) { logln("Import failed: "+ex.getMessage()); } }
+    public void snapshotToDatedFile() { try { Map<String,String> map = readAllPresetTags(); String date = new SimpleDateFormat("yyyyMMdd_HHmmss").format(new Date()); File f = new File("bank_layout_"+date+".json"); writeString(f, toJson(map)); logln("Snapshot saved: "+f.getAbsolutePath()); } catch (Exception ex) { logln("Snapshot failed: "+ex.getMessage()); } }
+
+    private void logln(String s) { logArea.append(s+"\n"); log.info(s); }
+
+    static class ItemStack { final int id; final int slot; final int qty; ItemStack(int id,int slot,int qty){this.id=id;this.slot=slot;this.qty=qty;} }
+
+    // Minimal JSON helpers (Map<String,String>)
+    private static String toJson(Map<String,String> map) {
+        StringBuilder sb=new StringBuilder();
+        sb.append("{\n");
+        boolean first=true;
+        for (Map.Entry<String,String> e: map.entrySet()) {
+            if(!first) sb.append(",\n");
+            first=false;
+            sb.append("  ").append(quote(e.getKey())).append(": ").append(quote(e.getValue()));
+        }
+        sb.append("\n}");
+        return sb.toString();
+    }
+    private static Map<String,String> fromJson(String json) {
+        Map<String,String> out=new LinkedHashMap<>();
+        String inner=json.trim();
+        if(inner.startsWith("{")&&inner.endsWith("}")) inner=inner.substring(1, inner.length()-1);
+        if(inner.trim().isEmpty()) return out;
+        String[] pairs=inner.split(",(?=(?:[^\\"]*\\"[^\\"]*\\")*[^\\"]*$)");
+        for(String pair:pairs){
+            String p=pair.trim(); if(p.isEmpty()) continue;
+            int idx=p.indexOf(":"); if(idx<0) continue;
+            String k=unquote(p.substring(0,idx).trim());
+            String v=unquote(p.substring(idx+1).trim());
+            out.put(k,v);
+        }
+        return out;
+    }
+    private static String quote(String s){ return "\""+s.replace("\\","\\\\").replace("\"","\\\"")+"\""; }
+    private static String unquote(String s){ s=s.trim(); if(s.startsWith("\"")&&s.endsWith("\"")) s=s.substring(1,s.length()-1); return s.replace("\\\"","\"").replace("\\\\","\\"); }
+
+    private static void writeString(File f, String s) throws IOException { try (FileWriter fw=new FileWriter(f)) { fw.write(s);} }
+    private static String readString(File f) throws IOException { StringBuilder sb=new StringBuilder(); try(BufferedReader br=new BufferedReader(new FileReader(f))){ String line; while((line=br.readLine())!=null) sb.append(line).append('\n'); } return sb.toString(); }
+    private static void copyToClipboard(String text) { try { java.awt.Toolkit.getDefaultToolkit().getSystemClipboard().setContents(new java.awt.datatransfer.StringSelection(text), null);} catch(Exception ignored){} }
+
+    private java.util.List<Integer> parseTabList(String spec, boolean includeMain) {
+        java.util.LinkedHashSet<Integer> set = new java.util.LinkedHashSet<>();
+        if (includeMain) set.add(0);
+        if (spec == null || spec.trim().isEmpty()) return new java.util.ArrayList<>(set);
+        for (String part : spec.split(",")) {
+            String p = part.trim(); if (p.isEmpty()) continue;
+            if (p.contains("-")) {
+                String[] ab = p.split("-"); if (ab.length==2) {
+                    try { int a = Integer.parseInt(ab[0].trim()); int b = Integer.parseInt(ab[1].trim()); if (a>b){int t=a;a=b;b=t;} for (int i=a;i<=b;i++) set.add(i);} catch (NumberFormatException ignored) {}
+                }
+            } else {
+                try { set.add(Integer.parseInt(p)); } catch (NumberFormatException ignored) {}
+            }
+        }
+        return new java.util.ArrayList<>(set);
+    }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bankorganizer/PresetPacks.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bankorganizer/PresetPacks.java
@@ -1,0 +1,98 @@
+package net.runelite.client.plugins.microbot.bankorganizer;
+
+final class PresetPacks {
+    private PresetPacks() {}
+
+    // Default prefilled Rule‑Editor JSON (master list)
+    static final String DEFAULT_RULES_JSON = """
+[
+  {"name":"TOA — Mage (Shadow/Support)","includeCategories":["RAIDS","COMBAT","ARMOUR","RUNES","POTIONS","FOOD","TELEPORTS"],"includeKeywords":["tumeken","shadow","virtus","ely","lightbearer","elidinis","ward","ancient","sceptre","blood rune","soul rune"]},
+  {"name":"TOA — Ranged (Masori/Fang swap)","includeCategories":["RAIDS","COMBAT","ARMOUR","AMMO","POTIONS","FOOD","TELEPORTS"],"includeKeywords":["masori","zaryte","bowfa","crystal","lightbearer","venator","keris","fang","elidinis"]},
+  {"name":"TOA — Melee (Fang/BGS)","includeCategories":["RAIDS","COMBAT","ARMOUR","POTIONS","FOOD","TELEPORTS"],"includeKeywords":["fang","keris","bandos godsword","justiciar","primordial","torture","inquisitor"]},
+  {"name":"COX — Ranged (Tbow/DHCB)","includeCategories":["RAIDS","COMBAT","ARMOUR","AMMO","POTIONS","FOOD","TELEPORTS"],"includeKeywords":["twisted","tbow","dragon hunter crossbow","crystal helm","crystal body","crystal legs","anguish","pegs"]},
+  {"name":"COX — Mage (Ancestral/Kodai)","includeCategories":["RAIDS","COMBAT","ARMOUR","RUNES","POTIONS","FOOD","TELEPORTS"],"includeKeywords":["ancestral","kodai","trident","harmonised","occult","tormented","blood rune","death rune"]},
+  {"name":"COX — Melee (DWH/Claw/BGS)","includeCategories":["RAIDS","COMBAT","ARMOUR","POTIONS","FOOD","TELEPORTS"],"includeKeywords":["dragon warhammer","claws","bandos godsword","bandos","primordial","torture","defender"]},
+  {"name":"TOB — Melee (Scythe/Avernic)","includeCategories":["RAIDS","COMBAT","ARMOUR","POTIONS","FOOD","TELEPORTS"],"includeKeywords":["scythe","ghrazi","avernic","justiciar","torture","ferocious","primordial"]},
+  {"name":"TOB — Mage (Sang/Arceuus)","includeCategories":["RAIDS","COMBAT","ARMOUR","RUNES","POTIONS","FOOD","TELEPORTS"],"includeKeywords":["sanguinesti","occult","tormented","ahrim","ancient","blood rune","death rune"]},
+  {"name":"Slayer — Demons (Arclight)","includeCategories":["SLAYER","COMBAT","ARMOUR","AMMO","POTIONS","FOOD","TELEPORTS"],"includeKeywords":["arclight","black mask","slayer helm","demon","holy water"]},
+  {"name":"Slayer — Dragons (Anti-fire)","includeCategories":["SLAYER","COMBAT","ARMOUR","AMMO","POTIONS","FOOD","TELEPORTS"],"includeKeywords":["anti-dragon","antifire","dragonfire shield","dragon hunter lance","extended antifire","ranging potion"]},
+  {"name":"Slayer — Undead (Salve)","includeCategories":["SLAYER","COMBAT","ARMOUR","AMMO","POTIONS","FOOD","TELEPORTS"],"includeKeywords":["salve","ivandis","undead","crumble undead","ensouled"]},
+  {"name":"Clue Prep — Universal","includeCategories":["CLUE","TELEPORTS","RUNES","TOOLS","FOOD","POTIONS"],"includeKeywords":["spade","sextant","chart","watch","stash","chronicle","games necklace","dueling ring","skills necklace"]},
+  {"name":"Clue — Easy","includeCategories":["CLUE","TELEPORTS","RUNES","TOOLS"],"includeKeywords":["chronicle","necklace of passage","games necklace","falador","varrock","camelot","ardougne"]},
+  {"name":"Clue — Medium","includeCategories":["CLUE","TELEPORTS","RUNES","TOOLS"],"includeKeywords":["digsite","slayer ring","ecto","khazard","fairy","miscellania","kandarin"]},
+  {"name":"Clue — Hard/Elite","includeCategories":["CLUE","TELEPORTS","RUNES","TOOLS"],"includeKeywords":["wilderness","gwd","ancient shard","xeric","karamja gloves","royal seed pod","ecto"]},
+  {"name":"Barrows — Sets","includeCategories":["BARROWS","ARMOUR","COMBAT","POTIONS","FOOD"],"includeKeywords":["ahrim","dharok","guthan","karil","torag","verac","karils","dharoks"]},
+  {"name":"Skilling — Woodcut/Fletch","includeCategories":["SKILLING","TOOLS"],"includeKeywords":["axe","knife","logs","bowstring","feather"]},
+  {"name":"Skilling — Fish/Cook","includeCategories":["SKILLING","TOOLS","FOOD","POTIONS"],"includeKeywords":["harpoon","net","cage","feather","karambwan","raw","cooking gauntlets"]},
+  {"name":"Ironman — Early Progress","includeCategories":["COMBAT","ARMOUR","TOOLS","TELEPORTS","FOOD","POTIONS"],"includeKeywords":["graceful","ardougne cloak","mythical","accumulator","glory","combat bracelet","rune"]},
+  {"name":"Ironman — Midgame Bossing","includeCategories":["COMBAT","ARMOUR","AMMO","POTIONS","FOOD","TELEPORTS"],"includeKeywords":["trident","whip","serp","blowpipe","void","salve","slayer helm","bandos","obby"]},
+  {"name":"Ironman — Late Bossing","includeCategories":["COMBAT","ARMOUR","AMMO","POTIONS","FOOD","TELEPORTS","RAIDS"],"includeKeywords":["tbow","scythe","sanguinesti","kodai","ancestral","justiciar","zaryte","lightbearer"]}
+]
+""";
+
+    static String forPack(BankOrganizerConfig.PresetPack pack) {
+        switch (pack) {
+            case RAIDS:
+                return join(
+                        rule("TOA — Mage (Shadow/Support)"),
+                        rule("TOA — Ranged (Masori/Fang swap)"),
+                        rule("TOA — Melee (Fang/BGS)"),
+                        rule("COX — Ranged (Tbow/DHCB)"),
+                        rule("COX — Mage (Ancestral/Kodai)"),
+                        rule("COX — Melee (DWH/Claw/BGS)"),
+                        rule("TOB — Melee (Scythe/Avernic)"),
+                        rule("TOB — Mage (Sang/Arceuus)")
+                );
+            case SLAYER:
+                return join(
+                        rule("Slayer — Demons (Arclight)"),
+                        rule("Slayer — Dragons (Anti-fire)"),
+                        rule("Slayer — Undead (Salve)")
+                );
+            case IRONMAN:
+                return join(
+                        rule("Ironman — Early Progress"),
+                        rule("Ironman — Midgame Bossing"),
+                        rule("Ironman — Late Bossing")
+                );
+            case SKILLING:
+                return join(
+                        rule("Skilling — Woodcut/Fletch"),
+                        rule("Skilling — Fish/Cook")
+                );
+            case BARROWS:
+                return join(rule("Barrows — Sets"));
+            case CLUES:
+                return join(
+                        rule("Clue Prep — Universal"),
+                        rule("Clue — Easy"),
+                        rule("Clue — Medium"),
+                        rule("Clue — Hard/Elite")
+                );
+            case ALL:
+                return DEFAULT_RULES_JSON;
+            case NONE:
+            default:
+                return "[]";
+        }
+    }
+
+    private static String rule(String name) {
+        String src = DEFAULT_RULES_JSON;
+        int i = src.indexOf("\"name\":\""+name);
+        if (i < 0) return "{}";
+        int start = src.lastIndexOf('{', i);
+        int end = src.indexOf('}', i);
+        return src.substring(start, end+1);
+    }
+
+    private static String join(String... objs) {
+        StringBuilder sb = new StringBuilder("[");
+        boolean first = true;
+        for (String o : objs) {
+            if (o == null || o.isEmpty() || o.equals("{}")) continue;
+            if (!first) sb.append(','); first = false; sb.append(o);
+        }
+        return sb.append(']').toString();
+    }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bankorganizer/TinyJson.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/bankorganizer/TinyJson.java
@@ -1,0 +1,88 @@
+package net.runelite.client.plugins.microbot.bankorganizer;
+
+final class TinyJson {
+    private TinyJson() {}
+
+    static java.util.List<java.util.Map<String,Object>> parseArrayOfObjects(String json) {
+        java.util.List<java.util.Map<String,Object>> out = new java.util.ArrayList<>();
+        if (json == null) return out;
+        String s = json.trim();
+        if (!s.startsWith("[") || !s.endsWith("]")) return out;
+        s = s.substring(1, s.length()-1).trim();
+        java.util.List<String> objs = splitTopObjects(s);
+        for (String obj : objs) out.add(parseObject(obj));
+        return out;
+    }
+
+    static java.util.Map<String,Object> parseObject(String obj) {
+        java.util.Map<String,Object> map = new java.util.LinkedHashMap<>();
+        if (obj == null) return map;
+        String s = obj.trim();
+        if (s.startsWith("{")) s = s.substring(1);
+        if (s.endsWith("}")) s = s.substring(0, s.length()-1);
+        java.util.List<String> pairs = splitTopPairs(s);
+        for (String p : pairs) {
+            int idx = p.indexOf(":");
+            if (idx < 0) continue;
+            String k = unq(p.substring(0, idx).trim());
+            String v = p.substring(idx+1).trim();
+            if (v.startsWith("[")) map.put(k, parseStringArray(v));
+            else map.put(k, unq(v));
+        }
+        return map;
+    }
+
+    private static java.util.List<String> splitTopObjects(String s) {
+        java.util.List<String> out = new java.util.ArrayList<>();
+        int depth = 0; int start = 0; boolean inStr=false;
+        for (int i=0;i<s.length();i++) {
+            char c = s.charAt(i);
+            if (c=='"') inStr=!inStr;
+            else if (!inStr && c=='{') depth++;
+            else if (!inStr && c=='}') depth--;
+            else if (!inStr && c==',' && depth==0) { out.add(s.substring(start, i)); start = i+1; }
+        }
+        if (start < s.length()) out.add(s.substring(start));
+        return out;
+    }
+
+    private static java.util.List<String> splitTopPairs(String s) {
+        java.util.List<String> out = new java.util.ArrayList<>();
+        int depth = 0; boolean inStr=false; int start=0;
+        for (int i=0;i<s.length();i++) {
+            char c=s.charAt(i);
+            if (c=='"') inStr=!inStr;
+            else if (!inStr && c=='[') depth++;
+            else if (!inStr && c==']') depth--;
+            else if (!inStr && depth==0 && c==',') { out.add(s.substring(start,i)); start=i+1; }
+        }
+        if (start < s.length()) out.add(s.substring(start));
+        return out;
+    }
+
+    private static java.util.List<String> parseStringArray(String v) {
+        String s = v.trim();
+        if (s.startsWith("[")) s=s.substring(1);
+        if (s.endsWith("]")) s=s.substring(0,s.length()-1);
+        java.util.List<String> out = new java.util.ArrayList<>();
+        boolean inStr=false; StringBuilder cur=new StringBuilder();
+        for (int i=0;i<s.length();i++) {
+            char c=s.charAt(i);
+            if (c=='"') { inStr=!inStr; continue; }
+            if (c==',' && !inStr) { out.add(unq(cur.toString().trim())); cur.setLength(0); continue; }
+            cur.append(c);
+        }
+        if (cur.length()>0) out.add(unq(cur.toString().trim()));
+        return out;
+    }
+
+    private static String unq(String x) {
+        String t = x.trim();
+        if (t.startsWith("\"") && t.endsWith("\"")) t = t.substring(1, t.length()-1);
+        t = t.replace("\\\"", "\"").replace("\\\\", "\\");
+        return t;
+    }
+
+    static String asString(Object o) { return o instanceof String ? (String)o : null; }
+    @SuppressWarnings("unchecked") static java.util.List<String> asStringList(Object o) { return (o instanceof java.util.List) ? (java.util.List<String>)o : java.util.Collections.emptyList(); }
+}


### PR DESCRIPTION
## Summary
- add Bank Organizer plugin for Microbot to scan, tag, and arrange bank items
- provide extensive configuration including combo tags, presets, multi-tab arrange, and rule-editor combos

## Testing
- `mvn -q -pl runelite-client -am test` *(fails: Non-resolvable import POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a507a8782c8330b5799b16faf85422