### PR TITLE
Add Grand Exchange flipper plugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/grandexchangeflipper/GrandExchangeFlipperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/grandexchangeflipper/GrandExchangeFlipperConfig.java
@@ -1,0 +1,26 @@
+package net.runelite.client.plugins.microbot.grandexchangeflipper;
+
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+
+@ConfigGroup("geflipper")
+public interface GrandExchangeFlipperConfig extends Config
+{
+    @ConfigItem(
+            keyName = "priceSource",
+            name = "Price source",
+            description = "Select price data source",
+            position = 0
+    )
+    default PriceSource priceSource()
+    {
+            return PriceSource.DEFAULT;
+    }
+
+    enum PriceSource
+    {
+            DEFAULT,
+            OSRS_WIKI
+    }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/grandexchangeflipper/GrandExchangeFlipperOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/grandexchangeflipper/GrandExchangeFlipperOverlay.java
@@ -1,0 +1,54 @@
+package net.runelite.client.plugins.microbot.grandexchangeflipper;
+
+import java.awt.Dimension;
+import java.awt.Graphics2D;
+import java.time.Duration;
+import javax.inject.Inject;
+import net.runelite.client.ui.overlay.OverlayPanel;
+import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.components.LineComponent;
+
+public class GrandExchangeFlipperOverlay extends OverlayPanel
+{
+    private final GrandExchangeFlipperScript script;
+
+    @Inject
+    public GrandExchangeFlipperOverlay(GrandExchangeFlipperScript script)
+    {
+        this.script = script;
+        setPosition(OverlayPosition.TOP_LEFT);
+    }
+
+    @Override
+    public Dimension render(Graphics2D graphics)
+    {
+        panelComponent.getChildren().clear();
+        panelComponent.getChildren().add(LineComponent.builder()
+                .left("Plugin Name:")
+                .right("Grand Exchange Flipper")
+                .build());
+        panelComponent.getChildren().add(LineComponent.builder()
+                .left("Plugin Version:")
+                .right(String.valueOf(GrandExchangeFlipperScript.VERSION))
+                .build());
+        panelComponent.getChildren().add(LineComponent.builder()
+                .left("Profit:")
+                .right(String.valueOf(script.getProfit()))
+                .build());
+        panelComponent.getChildren().add(LineComponent.builder()
+                .left("Status:")
+                .right(script.getStatus())
+                .build());
+        panelComponent.getChildren().add(LineComponent.builder()
+                .left("Run Time:")
+                .right(format(script.getRuntime()))
+                .build());
+        return super.render(graphics);
+    }
+
+    private String format(Duration d)
+    {
+        long s = d.getSeconds();
+        return String.format("%02d:%02d:%02d", s / 3600, (s % 3600) / 60, s % 60);
+    }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/grandexchangeflipper/GrandExchangeFlipperPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/grandexchangeflipper/GrandExchangeFlipperPanel.java
@@ -1,0 +1,26 @@
+package net.runelite.client.plugins.microbot.grandexchangeflipper;
+
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import net.runelite.client.ui.PluginPanel;
+
+public class GrandExchangeFlipperPanel extends PluginPanel
+{
+    private final JLabel latest = new JLabel("Latest: -");
+    private final JLabel profit = new JLabel("Profit: 0");
+
+    public GrandExchangeFlipperPanel()
+    {
+        super(false);
+        JPanel container = new JPanel();
+        container.add(latest);
+        container.add(profit);
+        add(container);
+    }
+
+    public void updateLatestFlip(String item, long flipProfit, long totalProfit)
+    {
+        latest.setText("Latest: " + item + " (" + flipProfit + ")");
+        profit.setText("Profit: " + totalProfit);
+    }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/grandexchangeflipper/GrandExchangeFlipperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/grandexchangeflipper/GrandExchangeFlipperPlugin.java
@@ -1,0 +1,72 @@
+package net.runelite.client.plugins.microbot.grandexchangeflipper;
+
+import com.google.inject.Provides;
+import java.awt.AWTException;
+import java.awt.image.BufferedImage;
+import javax.inject.Inject;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.ui.ClientToolbar;
+import net.runelite.client.ui.NavigationButton;
+import net.runelite.client.ui.overlay.OverlayManager;
+import net.runelite.client.util.ImageUtil;
+
+@PluginDescriptor(
+        name = PluginDescriptor.Microbot + "GE Flipper",
+        description = "Automatically flip items on the Grand Exchange",
+        tags = {"grand", "exchange", "flip"},
+        enabledByDefault = false
+)
+public class GrandExchangeFlipperPlugin extends Plugin
+{
+    @Inject
+    private OverlayManager overlayManager;
+
+    @Inject
+    private GrandExchangeFlipperOverlay overlay;
+
+    @Inject
+    private GrandExchangeFlipperScript script;
+
+    @Inject
+    private GrandExchangeFlipperConfig config;
+
+    @Inject
+    private ClientToolbar clientToolbar;
+
+    private NavigationButton navButton;
+
+    @Inject
+    private GrandExchangeFlipperPanel panel;
+
+    @Provides
+    GrandExchangeFlipperConfig provideConfig(ConfigManager configManager)
+    {
+        return configManager.getConfig(GrandExchangeFlipperConfig.class);
+    }
+
+    @Override
+    protected void startUp() throws AWTException
+    {
+        overlayManager.add(overlay);
+        final BufferedImage icon = ImageUtil.loadImageResource(GrandExchangeFlipperPlugin.class,
+                "/net/runelite/client/plugins/grandexchange/ge_icon.png");
+        navButton = NavigationButton.builder()
+                .tooltip("GE Flipper")
+                .icon(icon)
+                .priority(8)
+                .panel(panel)
+                .build();
+        clientToolbar.addNavigation(navButton);
+        script.run(this, panel);
+    }
+
+    @Override
+    protected void shutDown()
+    {
+        overlayManager.remove(overlay);
+        clientToolbar.removeNavigation(navButton);
+        script.shutdown();
+    }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/grandexchangeflipper/GrandExchangeFlipperScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/grandexchangeflipper/GrandExchangeFlipperScript.java
@@ -1,0 +1,298 @@
+package net.runelite.client.plugins.microbot.grandexchangeflipper;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.GrandExchangeOffer;
+import net.runelite.api.ItemComposition;
+import net.runelite.api.ItemID;
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.plugins.microbot.Script;
+import net.runelite.client.plugins.microbot.breakhandler.BreakHandlerScript;
+import net.runelite.client.plugins.microbot.util.grandexchange.GrandExchangeSlots;
+import net.runelite.client.plugins.microbot.util.grandexchange.Rs2GrandExchange;
+import net.runelite.client.plugins.microbot.util.grandexchange.models.WikiPrice;
+import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
+import net.runelite.client.plugins.microbot.util.player.Rs2Player;
+import net.runelite.client.plugins.microbot.util.antiban.Rs2AntibanSettings;
+import net.runelite.client.plugins.microbot.util.antiban.Rs2Antiban;
+import net.runelite.client.plugins.microbot.util.antiban.enums.ActivityIntensity;
+
+@Singleton
+@Slf4j
+public class GrandExchangeFlipperScript extends Script
+{
+    public static final double VERSION = 1.0;
+
+    private final List<Integer> f2pItems = new ArrayList<>();
+    private final List<Integer> memberItems = new ArrayList<>();
+
+    private final Map<Integer, Instant> cooldown = new HashMap<>();
+    private final Map<Integer, Integer> slotItem = new HashMap<>();
+    private final Map<Integer, Integer> slotBuyPrice = new HashMap<>();
+    private final Map<Integer, Integer> slotSellPrice = new HashMap<>();
+
+    @Inject
+    private GrandExchangeFlipperConfig config;
+
+    private long profit = 0;
+    private long startTime;
+    private GrandExchangeFlipperPanel panel;
+    private String status = "Idle";
+
+    private void setStatus(String status)
+    {
+        this.status = status;
+        Microbot.status = status;
+    }
+
+    private void buildItemLists()
+    {
+        if (!f2pItems.isEmpty() || !memberItems.isEmpty())
+        {
+            return;
+        }
+
+        for (Field field : ItemID.class.getDeclaredFields())
+        {
+            if (field.getType() != int.class)
+            {
+                continue;
+            }
+            try
+            {
+                int id = field.getInt(null);
+                ItemComposition composition = Microbot.getItemManager().getItemComposition(id);
+                if (composition == null || !composition.isTradeable())
+                {
+                    continue;
+                }
+                if (composition.isMembers())
+                {
+                    memberItems.add(id);
+                }
+                else
+                {
+                    f2pItems.add(id);
+                }
+            }
+            catch (IllegalAccessException ignored)
+            {
+            }
+        }
+    }
+
+    public boolean run(GrandExchangeFlipperPlugin plugin, GrandExchangeFlipperPanel panel)
+    {
+        this.panel = panel;
+        startTime = System.currentTimeMillis();
+        Microbot.getClientThread().invoke(this::buildItemLists);
+        Rs2AntibanSettings.naturalMouse = true;
+        Rs2Antiban.setActivityIntensity(ActivityIntensity.VERY_LOW);
+        setStatus("Starting");
+        mainScheduledFuture = scheduledExecutorService.scheduleWithFixedDelay(() ->
+        {
+            try
+            {
+                if (!Microbot.isLoggedIn())
+                {
+                    setStatus("Logged out");
+                    return;
+                }
+                if (BreakHandlerScript.breakIn > 0 && BreakHandlerScript.breakIn <= 60)
+                {
+                    setStatus("Preparing for break");
+                    Rs2GrandExchange.closeExchange();
+                    return;
+                }
+                if (Rs2GrandExchange.hasFinishedBuyingOffers() || Rs2GrandExchange.hasFinishedSellingOffers())
+                {
+                    setStatus("Collecting offers");
+                    Rs2GrandExchange.collectAllToInventory();
+                }
+                if (!Rs2GrandExchange.isOpen())
+                {
+                    setStatus("Opening GE");
+                    Rs2GrandExchange.openExchange();
+                    return;
+                }
+
+                int maxSlots = Rs2Player.isMember() ? 8 : 3;
+                setStatus("Managing offers");
+                for (int i = 0; i < maxSlots; i++)
+                {
+                    GrandExchangeOffer offer = Microbot.getClient().getGrandExchangeOffers()[i];
+                    if (offer == null)
+                    {
+                        continue;
+                    }
+                    switch (offer.getState())
+                    {
+                        case EMPTY:
+                            handleEmptySlot(i);
+                            break;
+                        case BOUGHT:
+                            handleBoughtSlot(i);
+                            break;
+                        case SOLD:
+                            handleSoldSlot(i);
+                            break;
+                        default:
+                            break;
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                log.error("Error in GE flipper", ex);
+            }
+        }, 0, 1500, TimeUnit.MILLISECONDS);
+        return true;
+    }
+
+    private void handleEmptySlot(int slot)
+    {
+        setStatus("Placing buy offer");
+        List<Integer> pool = new ArrayList<>(f2pItems);
+        if (Rs2Player.isMember())
+        {
+            pool.addAll(memberItems);
+        }
+        Collections.shuffle(pool);
+        for (int itemId : pool)
+        {
+            Instant last = cooldown.get(itemId);
+            if (last != null && Instant.now().isBefore(last.plus(Duration.ofHours(4))))
+            {
+                continue;
+            }
+            WikiPrice price;
+            try
+            {
+                if (config.priceSource() == GrandExchangeFlipperConfig.PriceSource.OSRS_WIKI)
+                {
+                    price = Rs2GrandExchange.getRealTimePrices(itemId);
+                }
+                else
+                {
+                    int buy = Rs2GrandExchange.getPrice(itemId);
+                    int sell = Rs2GrandExchange.getSellPrice(itemId);
+                    int volume = Rs2GrandExchange.getBuyingVolume(itemId);
+                    price = buy > 0 && sell > 0 ? new WikiPrice(buy, sell, volume) : null;
+                }
+            }
+            catch (Exception ex)
+            {
+                log.debug("No price for item {}", itemId, ex);
+                continue;
+            }
+            if (price == null || price.buyPrice <= 0 || price.sellPrice <= 0)
+            {
+                continue;
+            }
+            int coins = Rs2Inventory.itemQuantity(ItemID.COINS);
+            int quantity = Math.min(coins / price.sellPrice, 100);
+            if (quantity <= 0)
+            {
+                continue;
+            }
+            ItemComposition composition = Microbot.getClientThread().runOnClientThreadOptional(() ->
+                Microbot.getItemManager().getItemComposition(itemId)).orElse(null);
+            if (composition == null)
+            {
+                continue;
+            }
+            String name = composition.getName();
+            if (Rs2GrandExchange.buyItem(name, price.sellPrice, quantity))
+            {
+                slotItem.put(slot, itemId);
+                slotBuyPrice.put(slot, price.sellPrice);
+                slotSellPrice.put(slot, price.buyPrice);
+                cooldown.put(itemId, Instant.now());
+                break;
+            }
+        }
+    }
+
+    private void handleBoughtSlot(int slot)
+    {
+        setStatus("Selling items");
+        Integer itemId = slotItem.get(slot);
+        if (itemId == null)
+        {
+            return;
+        }
+        int quantity = Rs2GrandExchange.collectOfferAndGetQuantity(GrandExchangeSlots.values()[slot], false, itemId);
+        if (quantity <= 0)
+        {
+            return;
+        }
+        ItemComposition composition = Microbot.getClientThread().runOnClientThreadOptional(() ->
+            Microbot.getItemManager().getItemComposition(itemId)).orElse(null);
+        if (composition == null)
+        {
+            return;
+        }
+        String name = composition.getName();
+        int sellPrice = slotSellPrice.getOrDefault(slot, 0);
+        Rs2GrandExchange.sellItem(name, quantity, sellPrice);
+    }
+
+    private void handleSoldSlot(int slot)
+    {
+        setStatus("Collecting profits");
+        Integer itemId = slotItem.get(slot);
+        if (itemId == null)
+        {
+            return;
+        }
+        int quantity = Rs2GrandExchange.collectOfferAndGetQuantity(GrandExchangeSlots.values()[slot], false, itemId);
+        if (quantity <= 0)
+        {
+            return;
+        }
+        long itemProfit = (long) (slotSellPrice.get(slot) - slotBuyPrice.get(slot)) * quantity;
+        profit += itemProfit;
+        ItemComposition composition = Microbot.getClientThread().runOnClientThreadOptional(() ->
+            Microbot.getItemManager().getItemComposition(itemId)).orElse(null);
+        if (composition != null)
+        {
+            String name = composition.getName();
+            if (panel != null)
+            {
+                panel.updateLatestFlip(name, itemProfit, profit);
+            }
+        }
+        slotItem.remove(slot);
+        slotBuyPrice.remove(slot);
+        slotSellPrice.remove(slot);
+    }
+
+    public long getProfit()
+    {
+        return profit;
+    }
+
+    public Duration getRuntime()
+    {
+        if (startTime == 0)
+        {
+            return Duration.ZERO;
+        }
+        return Duration.ofMillis(System.currentTimeMillis() - startTime);
+    }
+
+    public String getStatus()
+    {
+        return status;
+    }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/grandexchange/Rs2GrandExchange.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/util/grandexchange/Rs2GrandExchange.java
@@ -65,9 +65,9 @@ public class Rs2GrandExchange
 	private static final String GE_TRACKER_API_URL = "https://www.ge-tracker.com/api/items/";
 	
 	// Wiki API for real-time prices (Alternative source)
-	private static final String WIKI_API_URL = "https://prices.runescape.wiki/api/v1/osrs/latest?id=";
-	private static final String WIKI_TIMESERIES_URL = "https://prices.runescape.wiki/api/v1/osrs/timeseries";
-	private static final String WIKI_MAPPING_URL = "https://prices.runescape.wiki/api/v1/osrs/mapping";
+        private static final String WIKI_API_URL = "https://oldschool.runescape.wiki/api/v1/osrs/latest?id=";
+        private static final String WIKI_TIMESERIES_URL = "https://oldschool.runescape.wiki/api/v1/osrs/timeseries";
+        private static final String WIKI_MAPPING_URL = "https://oldschool.runescape.wiki/api/v1/osrs/mapping";
 	
 	// Caches for different data types
 	private static final Map<Integer, WikiPrice> priceCache = new HashMap<>();


### PR DESCRIPTION
## Summary
- add config option to choose price source (default Microbot data or OSRS Wiki)
- fetch buy/sell prices from selected source when placing GE offers
- use oldschool.runescape.wiki for OSRS Wiki price lookups when configured

## Testing
- `mvn -q -pl runelite-client test` *(failed: Non-resolvable import POM: The following artifacts could not be resolved: com.google.inject:guice-bom:pom:4.1.0 (absent): Could not transfer artifact com.google.inject:guice-bom:pom:4.1.0 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a61971dfa0833089e1b45a06ea43ab