### PR TITLE
Add Grand Exchange flipping plugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/geflipper/GeFlipperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/geflipper/GeFlipperConfig.java
@@ -1,0 +1,8 @@
+package net.runelite.client.plugins.microbot.geflipper;
+
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+
+@ConfigGroup("geflipper")
+public interface GeFlipperConfig extends Config {
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/geflipper/GeFlipperOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/geflipper/GeFlipperOverlay.java
@@ -1,0 +1,55 @@
+package net.runelite.client.plugins.microbot.geflipper;
+
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.plugins.microbot.breakhandler.BreakHandlerScript;
+import net.runelite.client.ui.overlay.OverlayPanel;
+import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.components.LineComponent;
+import net.runelite.client.ui.overlay.components.TitleComponent;
+
+import javax.inject.Inject;
+import java.awt.*;
+
+public class GeFlipperOverlay extends OverlayPanel {
+    private final GeFlipperScript script;
+
+    @Inject
+    GeFlipperOverlay(GeFlipperPlugin plugin, GeFlipperScript script) {
+        super(plugin);
+        this.script = script;
+        setPosition(OverlayPosition.TOP_LEFT);
+        setNaughty();
+    }
+
+    @Override
+    public Dimension render(Graphics2D graphics) {
+        panelComponent.getChildren().clear();
+        panelComponent.setPreferredSize(new Dimension(200, 120));
+        panelComponent.getChildren().add(TitleComponent.builder()
+                .text("GE Flipper")
+                .color(Color.ORANGE)
+                .build());
+        panelComponent.getChildren().add(LineComponent.builder().build());
+        panelComponent.getChildren().add(LineComponent.builder()
+                .left("Plugin Name:")
+                .right("GE Flipper")
+                .build());
+        panelComponent.getChildren().add(LineComponent.builder()
+                .left("Plugin Version:")
+                .right(String.valueOf(GeFlipperScript.VERSION))
+                .build());
+        panelComponent.getChildren().add(LineComponent.builder()
+                .left("Profit:")
+                .right(script.getProfit() + " gp")
+                .build());
+        panelComponent.getChildren().add(LineComponent.builder()
+                .left("Status:")
+                .right(Microbot.status)
+                .build());
+        panelComponent.getChildren().add(LineComponent.builder()
+                .left("Run Time:")
+                .right(BreakHandlerScript.formatDuration(script.getRunTime()))
+                .build());
+        return super.render(graphics);
+    }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/geflipper/GeFlipperPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/geflipper/GeFlipperPanel.java
@@ -1,0 +1,33 @@
+package net.runelite.client.plugins.microbot.geflipper;
+
+import net.runelite.client.ui.ColorScheme;
+import net.runelite.client.ui.PluginPanel;
+
+import javax.inject.Singleton;
+import javax.swing.*;
+import java.awt.*;
+
+@Singleton
+public class GeFlipperPanel extends PluginPanel {
+    private final JLabel latestFlipLabel = new JLabel("Latest flip: none");
+    private final JLabel profitLabel = new JLabel("Profit: 0 gp");
+
+    public void init() {
+        setLayout(new BorderLayout());
+        setBackground(ColorScheme.DARK_GRAY_COLOR);
+        JPanel info = new JPanel();
+        info.setLayout(new GridLayout(0,1));
+        info.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+        info.add(latestFlipLabel);
+        info.add(profitLabel);
+        add(info, BorderLayout.NORTH);
+    }
+
+    public void updateLatestFlip(String text) {
+        SwingUtilities.invokeLater(() -> latestFlipLabel.setText("Latest flip: " + text));
+    }
+
+    public void updateProfit(long profit) {
+        SwingUtilities.invokeLater(() -> profitLabel.setText("Profit: " + profit + " gp"));
+    }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/geflipper/GeFlipperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/geflipper/GeFlipperPlugin.java
@@ -1,0 +1,65 @@
+package net.runelite.client.plugins.microbot.geflipper;
+
+import com.google.inject.Provides;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.ui.ClientToolbar;
+import net.runelite.client.ui.NavigationButton;
+import net.runelite.client.ui.overlay.OverlayManager;
+import net.runelite.client.util.ImageUtil;
+
+import javax.inject.Inject;
+import java.awt.AWTException;
+import java.awt.image.BufferedImage;
+
+@PluginDescriptor(
+        name = PluginDescriptor.Default + "GE Flipper",
+        description = "Grand Exchange flipper",
+        tags = {"grand", "exchange", "flip", "microbot"}
+)
+public class GeFlipperPlugin extends Plugin {
+    @Inject
+    private GeFlipperConfig config;
+    @Provides
+    GeFlipperConfig provideConfig(ConfigManager configManager) {
+        return configManager.getConfig(GeFlipperConfig.class);
+    }
+
+    @Inject
+    private OverlayManager overlayManager;
+    @Inject
+    private GeFlipperOverlay overlay;
+    @Inject
+    private GeFlipperScript script;
+    @Inject
+    private ClientToolbar clientToolbar;
+    @Inject
+    private GeFlipperPanel panel;
+
+    private NavigationButton navButton;
+
+    @Override
+    protected void startUp() throws AWTException {
+        panel.init();
+        overlayManager.add(overlay);
+        BufferedImage icon = ImageUtil.loadImageResource(getClass(), "flip.png");
+        navButton = NavigationButton.builder()
+                .tooltip("GE Flipper")
+                .icon(icon)
+                .priority(5)
+                .panel(panel)
+                .build();
+        clientToolbar.addNavigation(navButton);
+        script.run(config, panel);
+    }
+
+    @Override
+    protected void shutDown() {
+        script.shutdown();
+        overlayManager.remove(overlay);
+        if (navButton != null) {
+            clientToolbar.removeNavigation(navButton);
+        }
+    }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/geflipper/GeFlipperScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/geflipper/GeFlipperScript.java
@@ -1,0 +1,177 @@
+package net.runelite.client.plugins.microbot.geflipper;
+
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.GrandExchangeOffer;
+import net.runelite.api.GrandExchangeOfferState;
+import net.runelite.api.ItemComposition;
+import net.runelite.api.gameval.ItemID;
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.plugins.microbot.Script;
+import net.runelite.client.plugins.microbot.breakhandler.BreakHandlerScript;
+import net.runelite.client.plugins.microbot.util.antiban.Rs2Antiban;
+import net.runelite.client.plugins.microbot.util.antiban.Rs2AntibanSettings;
+import net.runelite.client.plugins.microbot.util.antiban.enums.ActivityIntensity;
+import net.runelite.client.plugins.microbot.util.grandexchange.GrandExchangeAction;
+import net.runelite.client.plugins.microbot.util.grandexchange.GrandExchangeRequest;
+import net.runelite.client.plugins.microbot.util.grandexchange.GrandExchangeSlots;
+import net.runelite.client.plugins.microbot.util.grandexchange.Rs2GrandExchange;
+import net.runelite.client.plugins.microbot.util.grandexchange.models.WikiPrice;
+import net.runelite.client.plugins.microbot.util.inventory.Rs2Inventory;
+
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+
+import static net.runelite.client.plugins.microbot.util.Global.sleepUntil;
+
+@Slf4j
+public class GeFlipperScript extends Script {
+    public static final double VERSION = 1.0;
+    private final Map<GrandExchangeSlots, FlipOffer> offers = new HashMap<>();
+    private final Map<Integer, Long> cooldown = new HashMap<>();
+    private long profit = 0;
+    private String latestFlip = "";
+    private GeFlipperPanel panel;
+
+    private final int[] F2P_ITEMS = new int[]{ItemID.LOBSTER, ItemID.COAL, ItemID.IRON_ORE, ItemID.SWORD_FISH, ItemID.NATURE_RUNE};
+    private final int[] MEMBER_ITEMS = new int[]{ItemID.RAW_SHARK, ItemID.DRAGON_BONES, ItemID.MAHOGANY_PLANK, ItemID.RUNE_BAR};
+
+    private static class FlipOffer {
+        int itemId;
+        int buyPrice;
+        int sellPrice;
+        int quantity;
+        boolean selling;
+        FlipOffer(int itemId, int buyPrice, int sellPrice, int quantity) {
+            this.itemId = itemId;
+            this.buyPrice = buyPrice;
+            this.sellPrice = sellPrice;
+            this.quantity = quantity;
+            this.selling = false;
+        }
+    }
+
+    public long getProfit() { return profit; }
+    public String getLatestFlip() { return latestFlip; }
+
+    public boolean run(GeFlipperConfig config, GeFlipperPanel panel) {
+        this.panel = panel;
+        Rs2AntibanSettings.naturalMouse = true;
+        Rs2Antiban.setActivityIntensity(ActivityIntensity.MEDIUM);
+        mainScheduledFuture = scheduledExecutorService.scheduleWithFixedDelay(() -> {
+            try {
+                if (!super.run() || !Microbot.isLoggedIn()) return;
+
+                if (BreakHandlerScript.breakIn >= 0 && BreakHandlerScript.breakIn <= 60) {
+                    Microbot.status = "Awaiting break";
+                    if (Rs2GrandExchange.isOpen()) {
+                        Rs2GrandExchange.closeExchange();
+                    }
+                    return;
+                }
+
+                if (!Rs2GrandExchange.isOpen()) {
+                    Rs2GrandExchange.openExchange();
+                    return;
+                }
+
+                handleCompletedOffers();
+                fillEmptySlots();
+
+            } catch (Exception e) {
+                log.error("GE flipper error {}", e.getMessage(), e);
+            }
+        }, 0, 3, TimeUnit.SECONDS);
+        return true;
+    }
+
+    private void handleCompletedOffers() {
+        for (GrandExchangeSlots slot : GrandExchangeSlots.values()) {
+            FlipOffer fo = offers.get(slot);
+            if (fo == null) continue;
+
+            if (!fo.selling && Rs2GrandExchange.hasBoughtOffer(slot)) {
+                Rs2GrandExchange.collectOffer(slot, false);
+                int bought = Rs2GrandExchange.getItemsBoughtFromOffer(slot);
+                fo.quantity = bought;
+                ItemComposition ic = Microbot.getRs2ItemManager().getItemDefinition(fo.itemId);
+                Microbot.status = "Selling " + ic.getName();
+                Rs2GrandExchange.processOffer(GrandExchangeRequest.builder()
+                        .slot(slot)
+                        .action(GrandExchangeAction.SELL)
+                        .itemName(ic.getName())
+                        .price(fo.sellPrice)
+                        .quantity(fo.quantity)
+                        .build());
+                fo.selling = true;
+                sleepUntil(() -> {
+                    GrandExchangeOffer offer = Microbot.getClient().getGrandExchangeOffers()[slot.ordinal()];
+                    return offer.getState() == GrandExchangeOfferState.SELLING;
+                }, 3000);
+            } else if (fo.selling && Rs2GrandExchange.hasSoldOffer(slot)) {
+                Rs2GrandExchange.collectOffer(slot, false);
+                long gain = (long) (fo.sellPrice - fo.buyPrice) * fo.quantity;
+                profit += gain;
+                ItemComposition ic = Microbot.getRs2ItemManager().getItemDefinition(fo.itemId);
+                latestFlip = ic.getName() + " +" + gain;
+                panel.updateLatestFlip(latestFlip);
+                panel.updateProfit(profit);
+                offers.remove(slot);
+                Microbot.status = "Idle";
+            }
+        }
+    }
+
+    private void fillEmptySlots() {
+        int coins = Rs2Inventory.count(ItemID.COINS);
+        List<Integer> pool = new ArrayList<>();
+        for (int id : F2P_ITEMS) pool.add(id);
+        if (Microbot.getClient().isMembersWorld()) {
+            for (int id : MEMBER_ITEMS) pool.add(id);
+        }
+        Collections.shuffle(pool);
+        for (GrandExchangeSlots slot : GrandExchangeSlots.values()) {
+            if (!slotIsEmpty(slot) || offers.containsKey(slot)) continue;
+            for (int itemId : pool) {
+                if (onCooldown(itemId)) continue;
+                WikiPrice price = Rs2GrandExchange.getRealTimePrices(itemId);
+                if (price == null) continue;
+                int sellPrice = price.getSellPrice();
+                if (sellPrice <= 0 || sellPrice > coins) continue;
+                int quantity = Math.max(1, Math.min(100, coins / sellPrice));
+                ItemComposition ic = Microbot.getRs2ItemManager().getItemDefinition(itemId);
+                Microbot.status = "Buying " + ic.getName();
+                Rs2GrandExchange.processOffer(GrandExchangeRequest.builder()
+                        .slot(slot)
+                        .action(GrandExchangeAction.BUY)
+                        .itemName(ic.getName())
+                        .price(sellPrice)
+                        .quantity(quantity)
+                        .build());
+                offers.put(slot, new FlipOffer(itemId, sellPrice, price.getBuyPrice(), quantity));
+                cooldown.put(itemId, System.currentTimeMillis());
+                sleepUntil(() -> {
+                    GrandExchangeOffer offer = Microbot.getClient().getGrandExchangeOffers()[slot.ordinal()];
+                    return offer.getState() == GrandExchangeOfferState.BUYING;
+                }, 3000);
+                return;
+            }
+        }
+    }
+
+    private boolean slotIsEmpty(GrandExchangeSlots slot) {
+        GrandExchangeOffer offer = Microbot.getClient().getGrandExchangeOffers()[slot.ordinal()];
+        return offer == null || offer.getState() == GrandExchangeOfferState.EMPTY;
+    }
+
+    private boolean onCooldown(int itemId) {
+        long now = System.currentTimeMillis();
+        return cooldown.containsKey(itemId) && now - cooldown.get(itemId) < TimeUnit.HOURS.toMillis(4);
+    }
+
+    @Override
+    public void shutdown() {
+        super.shutdown();
+        offers.clear();
+        cooldown.clear();
+    }
+}


### PR DESCRIPTION
## Summary
- add new GE flipper script to use all GE slots, manage break handler, and track profit
- show plugin data on overlay and side panel with latest flip and total profit
- configure natural mouse behaviour and membership-aware item lists

## Testing
- `mvn -q -pl runelite-client -am package -DskipTests` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a66f0c5ce48330a6716e694e2fbd93